### PR TITLE
Renames the model prefix in stregsystem fixture

### DIFF
--- a/stregsystem/fixtures/initial_data.json
+++ b/stregsystem/fixtures/initial_data.json
@@ -4,7 +4,7 @@
             "description": "Kaffestuen, KMD",
             "name": "CS Kaffestuen"
         },
-        "model": "streg.room",
+        "model": "stregsystem.room",
         "pk": "1"
     },
     {
@@ -13,7 +13,7 @@
             "name": "Limfjordsporter",
             "price": 900
         },
-        "model": "streg.product",
+        "model": "stregsystem.product",
         "pk": "1"
     },
     {
@@ -22,7 +22,7 @@
             "price": 900,
             "product": 1
         },
-        "model": "streg.oldprice",
+        "model": "stregsystem.oldprice",
         "pk": "1"
     },
     {
@@ -31,7 +31,7 @@
             "price": 900,
             "product": 1
         },
-        "model": "streg.oldprice",
+        "model": "stregsystem.oldprice",
         "pk": "2"
     },
     {
@@ -46,7 +46,7 @@
             "want_spam": 1,
             "year": "2007"
         },
-        "model": "streg.member",
+        "model": "stregsystem.member",
         "pk": "1"
     }
 ]


### PR DESCRIPTION
The old name was streg, it's now named stregsystem. We needed to fix
that.