### PR TITLE
Fixes name not showing up in quicksale

### DIFF
--- a/stregsystem/templates/stregsystem/index_sale.html
+++ b/stregsystem/templates/stregsystem/index_sale.html
@@ -8,11 +8,11 @@
 <b>
 {% autoescape off %}
 {{member.username}} har lige købt
-{% for bought in bought_list %}{% if forloop.last and not forloop.first %}
+{% for product in products %}{% if forloop.last and not forloop.first %}
  og 
 {% else %}{% if not forloop.first %},
 {% endif %}{% endif %}
-{{bought.count}} {{bought.product.name}}{% endfor %}
+{{product.name}}{% endfor %}
 for tilsammen {{cost|money}} kr.
 </b>
 </blink>

--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 import datetime
 
 from django.test import TestCase
@@ -88,6 +89,13 @@ class SaleViewTests(TestCase):
         (last_trans,) = args
         self.assertEqual(last_trans, PayTransaction(900))
 
+    def test_quicksale_has_status_line(self):
+        response = self.client.post(
+            reverse('quickbuy', args=(1,)),
+            {"quickbuy": "jokke 1"}
+        )
+
+        self.assertContains(response, "<b>jokke har lige købt Limfjordsporter for tilsammen 9.00 kr.</b>", html=True)
 
 class TransactionTests(TestCase):
     def test_pay_transaction_change_neg(self):

--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -72,7 +72,7 @@ def quicksale(request, room, member, bought_ids):
     news = __get_news()
     product_list = __get_productlist()
 
-    products = {}
+    products = list()
 
     # TODO: Make atomic
     transaction = PayTransaction()
@@ -82,7 +82,7 @@ def quicksale(request, room, member, bought_ids):
         for i in bought_ids:
             product = Product.objects.get(Q(pk=i), Q(active=True), Q(deactivate_date__gte=datetime.datetime.now()) | Q(
                 deactivate_date__isnull=True))
-            products[i] = product
+            products.append(product)
             transaction.add(product.price)
     except Product.DoesNotExist:
         return usermenu(request, room, member, None)
@@ -92,8 +92,7 @@ def quicksale(request, room, member, bought_ids):
 
     member.fulfill(transaction)
 
-    for i in bought_ids:
-        product = products[i]
+    for product in products:
         s = Sale(
             member=member,
             product=product,


### PR DESCRIPTION
I mistakenly removed the product array that shows during in the
quicksale status, during a refactor.

This adds it back, and also adds a test to make sure it doesn't happen
again.