### PR TITLE
Add pytz requirement to render graph in admin panel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.10.5
 Pillow==4.1.0
 Coverage==4.4.1
+pytz==2017.2


### PR DESCRIPTION
As of now, without pytz installed the graph will fail to load on the "Reports>Daily stats" page.