### PR TITLE
Add django-debug-toolbar when debugging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ regex==2017.07.28
 git+https://github.com/spulec/freezegun.git@385a78d004b0566c6cbf98c304fb89a57bad0005
 Django-Select2==5.11.1
 enum34==1.1.6;python_version<"3.4"
+django-debug-toolbar==1.8

--- a/treo/settings.py
+++ b/treo/settings.py
@@ -96,6 +96,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
@@ -106,6 +107,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
 ROOT_URLCONF = 'treo.urls'
@@ -194,3 +196,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
+
+INTERNAL_IPS = [
+    "127.0.0.1",
+]

--- a/treo/urls.py
+++ b/treo/urls.py
@@ -29,3 +29,9 @@ urlpatterns = [
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns


### PR DESCRIPTION
This enables the https://django-debug-toolbar.readthedocs.io/en/stable/index.html which is a useful tool for development, it's only used when accessing the server in debug mode from 127.0.0.1, i.e. while developing on a local machine. 