### PR TITLE
Disable autocomplete in index template

### DIFF
--- a/stregsystem/templates/stregsystem/index.html
+++ b/stregsystem/templates/stregsystem/index.html
@@ -28,7 +28,7 @@
 
 
 <center>
-    <form action="/{{room.id}}/sale/" method="post" id="focusform" name="focusform" onsubmit="document.getElementById('buybutton').disabled = true">{% csrf_token %}
+    <form autocomplete="off" action="/{{room.id}}/sale/" method="post" id="focusform" name="focusform" onsubmit="document.getElementById('buybutton').disabled = true">{% csrf_token %}
 {% block saleform %}
 <p>
 <label for="quickbuy">Quickbuy</label>


### PR DESCRIPTION
This pull request disables autocomplete in chrome. If it's not disabled, chrome will list previous inputs. A privacy concern for those whose drinking habits are considered unhealthy by the general public.