### PR TITLE
Made all datetimes timezone aware

### DIFF
--- a/stregreport/views.py
+++ b/stregreport/views.py
@@ -74,8 +74,8 @@ def _sales_to_user_in_period(username, start_date, end_date, product_list, produ
 
 
 def razzia_view(request):
-    default_start = datetime.date.today() - datetime.timedelta(days=-180)
-    default_end = datetime.date.today()
+    default_start = timezone.now().today() - datetime.timedelta(days=-180)
+    default_end = timezone.now().today()
     start = request.GET.get('start', default_start.isoformat())
     end = request.GET.get('end', default_end.isoformat())
     products = request.GET.get('products', "")
@@ -134,13 +134,13 @@ def razzia_wizard(request):
                     request.POST.get('products'),
                     request.POST.get('razzia_title')))
 
-    suggested_start_date = datetime.datetime.now() - datetime.timedelta(days=-180)
-    suggested_end_date = datetime.datetime.now()
+    suggested_start_date = timezone.now() - datetime.timedelta(days=-180)
+    suggested_end_date = timezone.now()
 
     start_date_picker = fields.DateField(
-        widget=extras.SelectDateWidget(years=[x for x in range(2000, datetime.datetime.now().year + 1)]))
+        widget=extras.SelectDateWidget(years=[x for x in range(2000, timezone.now().year + 1)]))
     end_date_picker = fields.DateField(
-        widget=extras.SelectDateWidget(years=[x for x in range(2000, datetime.datetime.now().year + 1)]))
+        widget=extras.SelectDateWidget(years=[x for x in range(2000, timezone.now().year + 1)]))
 
     return render(request, 'admin/stregsystem/razzia/wizard.html',
                   {
@@ -169,15 +169,15 @@ def sales_product(request, ids, from_time, to_time, error=None):
         return render(request, 'admin/stregsystem/report/error_invalidsalefetch.html', {'error': error})
 
     try:
-        from_date_time = datetime.datetime.strptime(from_time, date_format)
+        from_date_time = timezone.datetime.strptime(from_time, date_format)
     except (ValueError, TypeError):
-        from_date_time = first_of_month(datetime.datetime.now())
+        from_date_time = first_of_month(timezone.now())
     from_time = from_date_time.strftime(date_format)
 
     try:
-        to_date_time = late(datetime.datetime.strptime(to_time, date_format))
+        to_date_time = late(timezone.datetime.strptime(to_time, date_format))
     except (ValueError, TypeError):
-        to_date_time = datetime.datetime.now()
+        to_date_time = timezone.now()
     to_time = to_date_time.strftime(date_format)
     sales = []
     if ids is not None and len(ids) > 0:
@@ -223,7 +223,7 @@ def ranks_for_year(request, year):
     vitamin_stat_list = sale_product_rank(vitamin, from_time, to_time)
     from_time_string = from_time.strftime(FORMAT)
     to_time_string = to_time.strftime(FORMAT)
-    current_date = datetime.datetime.now()
+    current_date = timezone.now()
     is_ongoing = current_date > from_time and current_date <= to_time
     return render(request, 'admin/stregsystem/report/ranks.html', locals())
 
@@ -248,7 +248,7 @@ def sale_money_rank(from_time, to_time, rank_limit=10):
 
 # year of the last fjuleparty
 def last_fjule_party_year():
-    current_date = datetime.datetime.now()
+    current_date = timezone.now()
     fjule_party_this_year = fjule_party(current_date.year)
     if current_date > fjule_party_this_year:
         return current_date.year
@@ -257,7 +257,7 @@ def last_fjule_party_year():
 
 # year of the next fjuleparty
 def next_fjule_party_year():
-    current_date = datetime.datetime.now()
+    current_date = timezone.now()
     fjule_party_this_year = fjule_party(current_date.year)
     if current_date <= fjule_party_this_year:
         return current_date.year
@@ -266,7 +266,7 @@ def next_fjule_party_year():
 
 # date of fjuleparty (first friday of december) for the given year at 10 o'clock
 def fjule_party(year):
-    first_december = datetime.datetime(year, 12, 1, 22)
+    first_december = timezone.datetime(year, 12, 1, 22)
     days_to_add = (11 - first_december.weekday()) % 7
     return first_december + datetime.timedelta(days=days_to_add)
 
@@ -285,15 +285,15 @@ def parse_id_string(id_string):
 
 
 def late(date):
-    return datetime.datetime(date.year, date.month, date.day, 23, 59, 59)
+    return timezone.datetime(date.year, date.month, date.day, 23, 59, 59)
 
 
 def first_of_month(date):
-    return datetime.datetime(date.year, date.month, 1, 23, 59, 59)
+    return timezone.datetime(date.year, date.month, 1, 23, 59, 59)
 
 
 def daily(request):
-    current_date = datetime.datetime.now().replace(hour=0, minute=0, second=0)
+    current_date = timezone.now().replace(hour=0, minute=0, second=0)
     latest_sales = (Sale.objects
                     .prefetch_related('product', 'member')
                     .order_by('-timestamp')[:7])

--- a/stregsystem/fixtures/initial_data.json
+++ b/stregsystem/fixtures/initial_data.json
@@ -53,7 +53,7 @@
             "member": 1,
             "product": 2,
             "room": 1,
-            "timestamp": "2017-03-13T12:52:52.142Z",
+            "timestamp": "2017-03-13T12:52+00:00",
             "price": 100
         }
     },
@@ -64,7 +64,7 @@
             "member": 1,
             "product": 3,
             "room": 1,
-            "timestamp": "2017-03-13T12:52:52.142Z",
+            "timestamp": "2017-03-13T12:52:52+00:00",
             "price": 100
         }
     },
@@ -75,7 +75,7 @@
             "member": 1,
             "product": 3,
             "room": 1,
-            "timestamp": "2017-03-13T12:52:52.142Z",
+            "timestamp": "2017-03-13T12:52:52+00:00",
             "price": 100
         }
     },
@@ -86,7 +86,7 @@
             "member": 1,
             "product": 3,
             "room": 1,
-            "timestamp": "2017-03-13T12:52:52.142Z",
+            "timestamp": "2017-03-13T12:52:52+00:00",
             "price": 100
         }
     },
@@ -104,7 +104,7 @@
     },
     {
         "fields": {
-            "changed_on": "2007-07-11 22:21:02",
+            "changed_on": "2007-07-11 22:21:02+00:00",
             "price": 900,
             "product": 1
         },
@@ -113,7 +113,7 @@
     },
     {
         "fields": {
-            "changed_on": "2007-07-11 22:32:06",
+            "changed_on": "2007-07-11 22:32:06+00:00",
             "price": 900,
             "product": 1
         },
@@ -155,7 +155,7 @@
         "pk": 1,
         "fields": {
             "password": "pbkdf2_sha256$30000$ivRA8qABWClG$pxi2R4uyotlGpwa66RQuDOXFaO9JElQutMFJqXmnOdI=",
-            "last_login": "2017-09-22T09:26:03.388Z",
+            "last_login": "2017-09-22T09:26:03+00:00",
             "is_superuser": true,
             "username": "tester",
             "first_name": "test",
@@ -163,7 +163,7 @@
             "email": "",
             "is_staff": true,
             "is_active": true,
-            "date_joined": "2017-03-06T10:53:54Z",
+            "date_joined": "2017-03-06T10:53:54+00:00",
             "groups": [],
             "user_permissions": []
         }

--- a/stregsystem/fixtures/testdata.json
+++ b/stregsystem/fixtures/testdata.json
@@ -65,7 +65,7 @@
     "fields": {
       "product": 1,
       "price": 100,
-      "changed_on": "2017-03-13T12:43:28.044Z"
+      "changed_on": "2017-03-13T12:43:28.044+00:00"
     }
   },
   {
@@ -74,7 +74,7 @@
     "fields": {
       "product": 2,
       "price": 200,
-      "changed_on": "2017-03-13T12:43:40.784Z"
+      "changed_on": "2017-03-13T12:43:40.784+00:00"
     }
   },
   {
@@ -83,7 +83,7 @@
     "fields": {
       "product": 2,
       "price": 200,
-      "changed_on": "2017-03-13T12:43:42.151Z"
+      "changed_on": "2017-03-13T12:43:42.151+00:00"
     }
   },
   {
@@ -109,7 +109,7 @@
       "member": 1,
       "product": 1,
       "room": 1,
-      "timestamp": "2017-03-13T12:52:52.142Z",
+      "timestamp": "2017-03-13T12:52:52.142+00:00",
       "price": 100
     }
   },
@@ -120,7 +120,7 @@
       "member": 1,
       "product": 2,
       "room": 1,
-      "timestamp": "2017-03-13T12:54:12.423Z",
+      "timestamp": "2017-03-13T12:54:12.423+00:00",
       "price": 200
     }
   },
@@ -131,7 +131,7 @@
       "member": 1,
       "product": 13,
       "room": 1,
-      "timestamp": "2017-03-13T13:38:10.573Z",
+      "timestamp": "2017-03-13T13:38:10.573+00:00",
       "price": 300
     }
   },
@@ -140,7 +140,7 @@
     "pk": 1,
     "fields": {
       "password": "pbkdf2_sha256$30000$ivRA8qABWClG$pxi2R4uyotlGpwa66RQuDOXFaO9JElQutMFJqXmnOdI=",
-      "last_login": "2017-03-13T12:41:13.546Z",
+      "last_login": "2017-03-13T12:41:13.546+00:00",
       "is_superuser": true,
       "username": "tester",
       "first_name": "test",
@@ -148,7 +148,7 @@
       "email": "",
       "is_staff": true,
       "is_active": true,
-      "date_joined": "2017-03-06T10:53:54Z",
+      "date_joined": "2017-03-06T10:53:54+00:00",
       "groups": [],
       "user_permissions": []
     }

--- a/stregsystem/models.py
+++ b/stregsystem/models.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from stregsystem.deprecated import deprecated
 from stregsystem.templatetags.stregsystem_extras import money
+from stregsystem.utils import date_to_timezone_aware
 
 
 def price_display(value):
@@ -375,7 +376,7 @@ class Product(models.Model): # id automatisk...
             return 0
         return (
             self.sale_set
-            .filter(timestamp__gt=self.start_date)
+            .filter(timestamp__gt=date_to_timezone_aware(self.start_date))
             .aggregate(bought=Count("id"))["bought"])
 
     def is_active(self):

--- a/stregsystem/models.py
+++ b/stregsystem/models.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from stregsystem.deprecated import deprecated
 from stregsystem.templatetags.stregsystem_extras import money
-from stregsystem.utils import date_to_timezone_aware
+from stregsystem.utils import date_to_midnight
 
 
 def price_display(value):
@@ -376,7 +376,7 @@ class Product(models.Model): # id automatisk...
             return 0
         return (
             self.sale_set
-            .filter(timestamp__gt=date_to_timezone_aware(self.start_date))
+            .filter(timestamp__gt=date_to_midnight(self.start_date))
             .aggregate(bought=Count("id"))["bought"])
 
     def is_active(self):

--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -2,6 +2,7 @@
 import datetime
 from collections import Counter
 
+import pytz
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -357,7 +358,7 @@ class SaleViewTests(TestCase):
             price=100,
             active=True
         )
-        with freeze_time(datetime.datetime(2018, 1, 1)) as frozen_time:
+        with freeze_time(timezone.datetime(2018, 1, 1)) as frozen_time:
             for i in range(1, 3):
                 Sale.objects.create(
                     member=member,
@@ -365,7 +366,7 @@ class SaleViewTests(TestCase):
                     price=100,
                 )
                 frozen_time.tick()
-        give_multibuy_hint, sale_hints = stregsystem_views._multibuy_hint(datetime.datetime(2018, 1, 1), member)
+        give_multibuy_hint, sale_hints = stregsystem_views._multibuy_hint(timezone.datetime(2018, 1, 1, tzinfo=pytz.UTC), member)
         self.assertTrue(give_multibuy_hint)
         self.assertEqual(sale_hints, "{} {}:{}".format("jokke", coke.id, 2))
 
@@ -389,7 +390,7 @@ class UserInfoViewTests(TestCase):
             active=True
         )
         self.sales = []
-        with freeze_time(datetime.datetime(2000, 1, 1)) as frozen_time:
+        with freeze_time(timezone.datetime(2000, 1, 1)) as frozen_time:
             for i in range(1, 4):
                 self.sales.append(
                     Sale.objects.create(
@@ -400,7 +401,7 @@ class UserInfoViewTests(TestCase):
                 )
                 frozen_time.tick()
         self.payments = []
-        with freeze_time(datetime.datetime(2000, 1, 1)) as frozen_time:
+        with freeze_time(timezone.datetime(2000, 1, 1)) as frozen_time:
             for i in range(1, 3):
                 self.payments.append(
                     Payment.objects.create(
@@ -935,7 +936,7 @@ class MemberTests(TestCase):
                 alcohol_content_ml=15.18,
                 active=True))
 
-        with freeze_time(datetime.datetime(year=2000, month=1, day=1, hour=0,
+        with freeze_time(timezone.datetime(year=2000, month=1, day=1, hour=0,
                                            minute=0)) as ft:
             for i in range(5):
                 ft.tick(delta=datetime.timedelta(minutes=10))
@@ -945,7 +946,7 @@ class MemberTests(TestCase):
 
         # The last drink was at 2000/01/01 00:50:00
 
-        with freeze_time(datetime.datetime(year=2000, month=1, day=1, hour=0,
+        with freeze_time(timezone.datetime(year=2000, month=1, day=1, hour=0,
                                            minute=50)) as ft:
             self.assertAlmostEqual(
                 0.97,
@@ -964,7 +965,7 @@ class MemberTests(TestCase):
                 alcohol_content_ml=15.18,
                 active=True))
 
-        with freeze_time(datetime.datetime(year=2000, month=1, day=1, hour=0,
+        with freeze_time(timezone.datetime(year=2000, month=1, day=1, hour=0,
                                            minute=0)) as ft:
             for i in range(5):
                 ft.tick(delta=datetime.timedelta(minutes=10))
@@ -974,7 +975,7 @@ class MemberTests(TestCase):
 
         # The last drink was at 2000/01/01 00:50:00
 
-        with freeze_time(datetime.datetime(year=2000, month=1, day=1, hour=0,
+        with freeze_time(timezone.datetime(year=2000, month=1, day=1, hour=0,
                                            minute=50)) as ft:
             self.assertAlmostEqual(
                 1.15,
@@ -1362,7 +1363,6 @@ class QuickbuyParserTests(TestCase):
             parser.parse(buy_string)
 
 
-
 class RazziaTests(TestCase):
     def setUp(self):
         self.flan = Product.objects.create(name="FLan", price=1.0, active=True)
@@ -1371,8 +1371,6 @@ class RazziaTests(TestCase):
 
         self.alan = Member.objects.create(username="tester", firstname="Alan", lastname="Alansen")
         self.bob = Member.objects.create(username="bob", firstname="bob", lastname="bob")
-
-        self.some_time = datetime.datetime(2017, 2, 2)
 
         with freeze_time('2017-02-02'):
             Sale.objects.create(member=self.alan, product=self.flan, price=1.0)
@@ -1389,8 +1387,8 @@ class RazziaTests(TestCase):
     def test_sales_to_user_in_period(self):
         res = views._sales_to_user_in_period(
             self.alan.username,
-            self.some_time - datetime.timedelta(hours=10),
-            self.some_time + datetime.timedelta(days=15),
+            timezone.datetime(2017, 2, 1, 0, 0, tzinfo=pytz.UTC),
+            timezone.datetime(2017, 2, 17, 0, 0, tzinfo=pytz.UTC),
             [self.flan.id, self.flanmad.id],
             {self.flan.name: 0, self.flanmad.name: 0},
         )
@@ -1401,8 +1399,8 @@ class RazziaTests(TestCase):
     def test_sales_to_user_no_results_out_of_period(self):
         res = views._sales_to_user_in_period(
             self.bob.username,
-            self.some_time + datetime.timedelta(days=14),
-            self.some_time + datetime.timedelta(days=15),
+            timezone.datetime(2017, 2, 1, 0, 0, tzinfo=pytz.UTC),
+            timezone.datetime(2017, 2, 17, 0, 0, tzinfo=pytz.UTC),
             [self.flan.id, self.flanmad.id],
             {self.flan.name: 0, self.flanmad.name: 0},
         )

--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -1033,14 +1033,14 @@ class ProductActivatedListFilterTests(TestCase):
             name="active_dec_future",
             price=1.0,
             active=True,
-            deactivate_date=(datetime.datetime.now()
+            deactivate_date=(timezone.now()
                              + datetime.timedelta(hours=1))
         )
         Product.objects.create(
             name="active_dec_past",
             price=1.0,
             active=True,
-            deactivate_date=(datetime.datetime.now()
+            deactivate_date=(timezone.now()
                              - datetime.timedelta(hours=1))
         )
 
@@ -1054,14 +1054,14 @@ class ProductActivatedListFilterTests(TestCase):
             name="deactivated_dec_future",
             price=1.0,
             active=False,
-            deactivate_date=(datetime.datetime.now()
+            deactivate_date=(timezone.now()
                              + datetime.timedelta(hours=1))
         )
         Product.objects.create(
             name="deactivated_dec_past",
             price=1.0,
             active=False,
-            deactivate_date=(datetime.datetime.now()
+            deactivate_date=(timezone.now()
                              - datetime.timedelta(hours=1))
         )
         p = Product.objects.create(

--- a/stregsystem/utils.py
+++ b/stregsystem/utils.py
@@ -1,10 +1,11 @@
 import datetime
 
 from django.db.models import Count, F, Q
+from django.utils import timezone
 
 
 def make_active_productlist_query(queryset):
-    now = datetime.datetime.now()
+    now = timezone.now()
     # Create a query for the set of products that MIGHT be active. Might
     # because they can be out of stock. Which we compute later
     active_candidates = (
@@ -31,7 +32,7 @@ def make_active_productlist_query(queryset):
 
 
 def make_inactive_productlist_query(queryset):
-    now = datetime.datetime.now()
+    now = timezone.now()
     # Create a query of things are definitively inactive. Some of the ones
     # filtered here might be out of stock, but we include that later.
     inactive_candidates = (

--- a/stregsystem/utils.py
+++ b/stregsystem/utils.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytz
 from django.db.models import Count, F, Q
 from django.utils import timezone
 
@@ -61,3 +62,7 @@ def make_room_specific_query(room):
     return (
         Q(rooms__id=room) | Q(rooms=None)
     )
+
+
+def date_to_timezone_aware(date):
+    return timezone.datetime(date.year, date.month, date.day, tzinfo=pytz.UTC)

--- a/stregsystem/utils.py
+++ b/stregsystem/utils.py
@@ -64,5 +64,11 @@ def make_room_specific_query(room):
     )
 
 
-def date_to_timezone_aware(date):
-    return timezone.datetime(date.year, date.month, date.day, tzinfo=pytz.UTC)
+def date_to_midnight(date):
+    """
+    Converts a datetime.date to a datetime of the same date at midnight.
+
+    :param date: date to convert
+    :return: the date as a timezone aware datetime at midnight
+    """
+    return timezone.make_aware(timezone.datetime(date.year, date.month, date.day, 0, 0))

--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -1,12 +1,9 @@
 import datetime
-from functools import reduce
 
 from django.db.models import Q
 from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
-
-import stregsystem.parser as parser
 
 import stregsystem.parser as parser
 from stregsystem.models import (
@@ -23,13 +20,12 @@ from stregsystem.utils import (
     make_active_productlist_query,
     make_room_specific_query
 )
-
 from .booze import ballmer_peak
 
 
 def __get_news():
     try:
-        return News.objects.filter(stop_date__gte=datetime.datetime.now(), pub_date__lte=datetime.datetime.now()).get()
+        return News.objects.filter(stop_date__gte=timezone.now(), pub_date__lte=timezone.now()).get()
     except News.DoesNotExist:
         return None
 
@@ -194,7 +190,7 @@ def menu_sale(request, room_id, member_id, product_id=None):
     product = None
     try:
         product = Product.objects.get(Q(pk=product_id), Q(active=True), Q(rooms__id=room_id) | Q(rooms=None),
-                                      Q(deactivate_date__gte=datetime.datetime.now()) | Q(deactivate_date__isnull=True))
+                                      Q(deactivate_date__gte=timezone.now()) | Q(deactivate_date__isnull=True))
 
         order = Order.from_products(
             member=member,


### PR DESCRIPTION
This will correct all the annoying warnings we get. 

We should always use `from django.utils import timezone` and `timezone.now()` to get a timestamp from now on please. 