### PR TITLE
Fix bug in advent candle in browsers where classList is not supported

### DIFF
--- a/stregsystem/templates/stregsystem/adventcandle.html
+++ b/stregsystem/templates/stregsystem/adventcandle.html
@@ -440,7 +440,7 @@
 
       for (var i = 1; i < dayOfMonth; i++) {
         var dateLabel = document.getElementById("day_" + i);
-        dateLabel.classList.add("day_hidden");
+        dateLabel.className += " day_hidden";
       }
 
       var hour = new Date().getHours();


### PR DESCRIPTION
As of now the Pi in Jægerstuen does not shrink the advent candle because the javascript crashes when hiding the numbers.