### PR TITLE
Add simple user statistics about sales

### DIFF
--- a/stregsystem/templates/stregsystem/menu_userinfo.html
+++ b/stregsystem/templates/stregsystem/menu_userinfo.html
@@ -86,5 +86,35 @@ Ingen indbetalinger!
    </tr>
 </table>
 
+<br />
+
+<center><b>Vi har beregnet følgende statistikker om dig</b></center>
+<table border=1 width="100%">
+   <tr>
+      <th align="left">Felt</th>
+      <th align="right">Værdi</th>
+   </tr>
+   <tr>
+      <td>Totale antal køb</td>
+      <td align="right">{{sale_statistics.number_sales}}</td>
+   </tr>
+   <tr>
+      <td>Total købspris</td>
+      <td align="right">{{sale_statistics.total_price|money}}</td>
+   </tr>
+   <tr>
+      <td>Gennemsnitlig købspris</td>
+      <td align="right">{{sale_statistics.average_price|money}}</td>
+   </tr>
+   <tr>
+      <td>Minimal købspris</td>
+      <td align="right">{{sale_statistics.min_price|money}}</td>
+   </tr>
+   <tr>
+      <td>Maksimal købspris</td>
+      <td align="right">{{sale_statistics.max_price|money}}</td>
+   </tr>
+</table>
+
 {% endblock %}
 

--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -3,7 +3,7 @@ import datetime
 import stregsystem.parser as parser
 from django.contrib.admin.views.decorators import staff_member_required
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Q, Avg, Count, Min, Max, Sum
 from django import forms
 from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
@@ -185,6 +185,14 @@ def menu_userinfo(request, room_id, member_id):
         last_payment = member.payment_set.order_by('-timestamp')[0]
     except IndexError:
         last_payment = None
+
+    sale_statistics = member.sale_set.aggregate(
+        number_sales=Count('timestamp'),
+        total_price=Sum('price'),
+        average_price=Avg('price'),
+        min_price=Min('price'),
+        max_price=Max('price')
+    )
 
     negative_balance = member.balance < 0
     stregforbud = member.has_stregforbud()


### PR DESCRIPTION
As shown by #163, there is some interest in statistics, but concern about making global high-score lists. This pull request adds simple sale statistics (count, sum, average, min, and max) to the user info page. That way, users can themselves decide if and when they look and compare.

If this feature is successful, more statistics can be added, such as most bought item (with count), average time between purchases, earliest purchase in the morning or latest at night, etc.

The feature has been tested for users with zero purchases, where it just shows zeroes for all statistics.