### PR TITLE
Avoid duplicate member usernames

### DIFF
--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -35,13 +35,6 @@ from stregsystem.models import (
     price_display
 )
 
-class MockRequest():
-    pass
-
-class MockFormChanges():
-    def __init__(self, data):
-        self.changed_data = data
-
 
 def assertCountEqual(case, *args, **kwargs):
     try:


### PR DESCRIPTION
This PR adds error messages when new fembers are created with usernames that already exists. If an existing member is updated with a duplicate username, a warning message is shown for backwards compatibility with duplicate usernames. 

This feature was requested by TREO'en.