### PR TITLE
Feature easter egg username replacements

### DIFF
--- a/stregsystem/static/stregsystem/gdpr.js
+++ b/stregsystem/static/stregsystem/gdpr.js
@@ -6,10 +6,17 @@ Simply replaces the letters with 'x'.
 var username_element = document.querySelectorAll(".username");
 
 if (username_element.length > 0) {
-  setTimeout(function () {
-    var username_element = document.querySelectorAll(".username");
-    for (var i = 0; i < username_element.length; i++) {
-    	username_element[i].innerText = "xxxxxxxx";
-    }
-  }, 5000);
+    setTimeout(function () {
+        var username_element = document.querySelectorAll(".username");
+        var replaced_username = "[username_hidden]";
+        var date = new Date();
+        // Only do username memes on April Fools
+        if (date.getDate() === 1 && date.getMonth() + 1 === 4) {
+            const easter_egg_names = ["user", "admin", "root", "alan_turing", "hackerman", "hans_huttel"];
+            replaced_username = easter_egg_names[Math.floor(Math.random() * easter_egg_names.length)];
+        }
+        for (var i = 0; i < username_element.length; i++) {
+            username_element[i].innerText = replaced_username;
+        }
+    }, 5000);
 }


### PR DESCRIPTION
Very similar to #155 but utilises the username-hider feature #182, so the replaced username is on-screen until the next user approaches. Therefore, more people should be able to see the replaced usernames.

Allowing the feature to trigger at another interval could make it more than a once-a-year occurrence. Each Friday, maybe? 

The ordinary replacement 'xxxxxxxx' is replaced with '[username_hidden]' for clarity _but mostly personal preference_.