### PR TITLE
Update freezegun dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Pillow==6.2.0
 Coverage==4.4.1
 pytz==2018.3
 regex==2017.07.28
-git+https://github.com/spulec/freezegun.git@39a0f1c103e734e1f88a788e956e7c9fcffb7918
+freezegun==0.3.15
 Django-Select2==5.11.1
 django-debug-toolbar==1.8


### PR DESCRIPTION
Update freezegun to use version instead of git commit and work with python 3.8