### PR TITLE
Added ability to view logentries as admin

### DIFF
--- a/stregsystem/admin.py
+++ b/stregsystem/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django import forms
 from django.contrib.admin.views.autocomplete import AutocompleteJsonView
 from django.contrib import messages
+from django.contrib.admin.models import LogEntry
 
 from stregsystem.models import (
     Category,
@@ -243,7 +244,27 @@ class PaymentAdmin(admin.ModelAdmin):
     get_amount_display.short_description = "Amount"
     get_amount_display.admin_order_field = "amount"
 
+class LogEntryAdmin(admin.ModelAdmin):
+    date_hierarchy = 'action_time'
+    list_filter = ['user', 'content_type', 'action_flag']
+    search_fields = ['object_repr', 'change_message']
+    list_display = ['action_time', 'user', 'content_type', 'object_id', 'action_flag', 'change_message']
 
+    def has_view_permission(self, request, obj=None):
+        return True
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+    
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    
+
+admin.site.register(LogEntry, LogEntryAdmin)
 admin.site.register(Sale, SaleAdmin)
 admin.site.register(Member, MemberAdmin)
 admin.site.register(Payment, PaymentAdmin)

--- a/stregsystem/admin.py
+++ b/stregsystem/admin.py
@@ -248,10 +248,10 @@ class LogEntryAdmin(admin.ModelAdmin):
     date_hierarchy = 'action_time'
     list_filter = ['content_type', 'action_flag']
     search_fields = ['object_repr', 'change_message', 'user__username']
-    list_display = ['action_time', 'user', 'content_type', 'object_id', 'action_flag', 'change_message']
+    list_display = ['action_time', 'user', 'content_type', 'object_id', 'action_flag', 'change_message', 'object_repr']
 
     def has_view_permission(self, request, obj=None):
-        return True
+        return request.user.is_superuser
 
     def has_add_permission(self, request):
         return False

--- a/stregsystem/admin.py
+++ b/stregsystem/admin.py
@@ -246,8 +246,8 @@ class PaymentAdmin(admin.ModelAdmin):
 
 class LogEntryAdmin(admin.ModelAdmin):
     date_hierarchy = 'action_time'
-    list_filter = ['user', 'content_type', 'action_flag']
-    search_fields = ['object_repr', 'change_message']
+    list_filter = ['content_type', 'action_flag']
+    search_fields = ['object_repr', 'change_message', 'user__username']
     list_display = ['action_time', 'user', 'content_type', 'object_id', 'action_flag', 'change_message']
 
     def has_view_permission(self, request, obj=None):

--- a/stregsystem/templates/admin/index.html
+++ b/stregsystem/templates/admin/index.html
@@ -20,7 +20,7 @@
         <caption><a href="{{ app.app_url }}" class="section">{% blocktrans with app.name as name %}{{ name }}{% endblocktrans %}</a></caption>
         {% for model in app.models %}
             <tr>
-            {% if model.perms.change %}
+            {% if model.perms.view %}
                 <th scope="row"><a href="{{ model.admin_url }}">{{ model.name }}</a></th>
             {% else %}
                 <th scope="row">{{ model.name }}</th>


### PR DESCRIPTION
Fixes #206 

Adds the ability to see the logs like this:
![image](https://user-images.githubusercontent.com/5766695/94344476-fcc9c580-001f-11eb-865b-981b47b2ace4.png)

However, this also adds it to the top of the applist.
![image](https://user-images.githubusercontent.com/5766695/94344506-22ef6580-0020-11eb-85d7-4d193c95dda8.png)

I see this as a good thing as we then can see who makes balance changes if we write to the LogEntry.