### PR TITLE
Bugfix escape username

### DIFF
--- a/stregsystem/templates/stregsystem/menu.html
+++ b/stregsystem/templates/stregsystem/menu.html
@@ -107,16 +107,18 @@ har {{member.balance|money}} kroner til gode!
 {% else %}
 <p>Ingen produkter.</p>
 {% endif %}
+{% endautoescape %}
+{% endblock %}
 </center>
 <br />
 {% if give_multibuy_hint %}
     <center>
         <h1>psssst. multibuy er enabled.</h1>
+        {% autoescape off %}
         <b> Du kunne have skrevet: {{sale_hints}} </b>
+        {% endautoescape %}
     </center>
 {% endif %}
-{% endautoescape %}
-{% endblock %}
 <div style="clear: both;">&nbsp;</div>
 
 {% endblock %}

--- a/stregsystem/templates/stregsystem/menu.html
+++ b/stregsystem/templates/stregsystem/menu.html
@@ -111,8 +111,8 @@ har {{member.balance|money}} kroner til gode!
 <br />
 {% if give_multibuy_hint %}
     <center>
-      <h1>psssst. multibuy er enabled.</h1>
-      <b> Du kunne have skrevet: {{sale_hints}} </b>
+        <h1>psssst. multibuy er enabled.</h1>
+        <b> Du kunne have skrevet: {{sale_hints}} </b>
     </center>
 {% endif %}
 {% endautoescape %}

--- a/stregsystem/templates/stregsystem/menu.html
+++ b/stregsystem/templates/stregsystem/menu.html
@@ -110,10 +110,10 @@ har {{member.balance|money}} kroner til gode!
 </center>
 <br />
 {% if give_multibuy_hint %}
-<center>
-  <h1>psssst. multibuy er enabled.</h1>
-  <b> Du kunne have skrevet: {{sale_hints}} </b>
-</center>
+  <center>
+    <h1>psssst. multibuy er enabled.</h1>
+    <b> Du kunne have skrevet: {{sale_hints}} </b>
+  </center>
 {% endif %}
 {% endautoescape %}
 {% endblock %}

--- a/stregsystem/templates/stregsystem/menu.html
+++ b/stregsystem/templates/stregsystem/menu.html
@@ -107,16 +107,16 @@ har {{member.balance|money}} kroner til gode!
 {% else %}
 <p>Ingen produkter.</p>
 {% endif %}
-{% endautoescape %}
-{% endblock %}
 </center>
 <br />
 {% if give_multibuy_hint %}
-    <center>
-        <h1>psssst. multibuy er enabled.</h1>
-        <b> Du kunne have skrevet: {{sale_hints}} </b>
-    </center>
+<center>
+  <h1>psssst. multibuy er enabled.</h1>
+  <b> Du kunne have skrevet: {{sale_hints}} </b>
+</center>
 {% endif %}
+{% endautoescape %}
+{% endblock %}
 <div style="clear: both;">&nbsp;</div>
 
 {% endblock %}

--- a/stregsystem/templates/stregsystem/menu.html
+++ b/stregsystem/templates/stregsystem/menu.html
@@ -110,10 +110,10 @@ har {{member.balance|money}} kroner til gode!
 </center>
 <br />
 {% if give_multibuy_hint %}
-  <center>
-    <h1>psssst. multibuy er enabled.</h1>
-    <b> Du kunne have skrevet: {{sale_hints}} </b>
-  </center>
+    <center>
+      <h1>psssst. multibuy er enabled.</h1>
+      <b> Du kunne have skrevet: {{sale_hints}} </b>
+    </center>
 {% endif %}
 {% endautoescape %}
 {% endblock %}


### PR DESCRIPTION
The `sales_hint` was unescaped, resulting in the following hint:
![image](https://user-images.githubusercontent.com/5766695/95477076-3e476280-0988-11eb-9661-5bbcc6d0804a.png)


After this fix, it should be presented as this:
![image](https://user-images.githubusercontent.com/5766695/95477141-4f906f00-0988-11eb-9247-edf0e94c3c9c.png)


If this is accepted, please squash the commit since I made some indentation errors :)