### PR TITLE
Added initial support for reimbursement

### DIFF
--- a/stregsystem/admin.py
+++ b/stregsystem/admin.py
@@ -21,7 +21,7 @@ from stregsystem.utils import (
 
 class SaleAdmin(admin.ModelAdmin):
     list_filter = ('room', 'timestamp')
-    list_display = ('get_username', 'get_fullname', 'get_product_name', 'get_room_name', 'timestamp', 'get_price_display')
+    list_display = ('get_username', 'get_fullname', 'get_product_name', 'get_room_name', 'timestamp', 'get_price_display', 'is_reimbursed')
     actions = ['refund']
     search_fields = ['^member__username', '=product__id', 'product__name']
     valid_lookups = ('member')
@@ -221,7 +221,7 @@ class MemberAdmin(admin.ModelAdmin):
 
 
 class PaymentAdmin(admin.ModelAdmin):
-    list_display = ('get_username', 'timestamp', 'get_amount_display')
+    list_display = ('get_username', 'timestamp', 'get_amount_display', 'is_reimbursement')
     valid_lookups = ('member')
     search_fields = ['member__username']
     autocomplete_fields = ['member']

--- a/stregsystem/migrations/0011_added_reimbursement.py
+++ b/stregsystem/migrations/0011_added_reimbursement.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stregsystem', '0010_auto_20200305_0917'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='payment',
+            name='is_reimbursement',
+            field=models.BooleanField(default=False, help_text='Viser om en betaling er tilbageført'),
+        ),
+        migrations.AddField(
+            model_name='sale',
+            name='is_reimbursed',
+            field=models.BooleanField(default=False, help_text='Viser om et salg er tilbageført'),
+        ),
+    ]

--- a/stregsystem/models.py
+++ b/stregsystem/models.py
@@ -137,6 +137,19 @@ class Order(object):
         # We changed the user balance, so save that
         self.member.save()
 
+class Reimbursement(object):
+    #Limits the amount of hours a reimbursement is available.
+    MAX_REIMBUSEMENT_HOURS = 12
+
+    @transaction.atomic
+    def from_sale(sale_id):
+        sale = Sale.objects.get(id=sale_id)
+        if not sale.is_reimbursable:
+            return
+        sale.is_reimbursed = True
+        sale.save()
+        Payment.objects.create(amount=sale.price, member=sale.member, is_reimbursement=True)
+
 
 class GetTransaction(MoneyTransaction):
     # The change to the users account
@@ -286,6 +299,8 @@ class Payment(models.Model):  # id automatisk...
     member = models.ForeignKey(Member, on_delete=models.CASCADE)
     timestamp = models.DateTimeField(auto_now_add=True)
     amount = models.IntegerField()  # penge, oere...
+    is_reimbursement = models.BooleanField(default=False, null=False,
+                                            help_text='Viser om en betaling er tilbageført')
 
     @deprecated
     def amount_display(self):
@@ -425,6 +440,8 @@ class Sale(models.Model):
     room = models.ForeignKey(Room, on_delete=models.CASCADE, null=True)
     timestamp = models.DateTimeField(auto_now_add=True)
     price = models.IntegerField()
+    is_reimbursed = models.BooleanField(default=False, null=False, 
+                                        help_text='Viser om et salg er tilbageført',)
 
     class Meta:
         index_together = [
@@ -442,6 +459,16 @@ class Sale(models.Model):
     # XXX - django bug - kan ikke vaelge mellem desc og asc i admin, som ved normalt felt
     price_display.admin_order_field = 'price'
 
+    def is_reimbursable(self):
+        if self.is_reimbursed:
+            return False
+        from datetime import timedelta
+
+        now = timezone.now()
+        # Only reimbursable up to a certain time.
+        return timedelta(hours=Reimbursement.MAX_REIMBUSEMENT_HOURS) >= now - self.timestamp
+        
+
     @deprecated
     def __unicode__(self):
         return self.__str__()
@@ -449,10 +476,10 @@ class Sale(models.Model):
     def __str__(self):
         return self.member.username + " " + self.product.name + " (" + money(self.price) + ") " + str(self.timestamp)
 
-    def save(self, *args, **kwargs):
-        if self.id:
-            raise RuntimeError("Updates of sales are not allowed")
-        super(Sale, self).save(*args, **kwargs)
+    #def save(self, *args, **kwargs):
+    #    if self.id:
+    #        raise RuntimeError("Updates of sales are not allowed")
+    #    super(Sale, self).save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
         if self.id:

--- a/stregsystem/templates/stregsystem/menu_userinfo.html
+++ b/stregsystem/templates/stregsystem/menu_userinfo.html
@@ -39,6 +39,7 @@ Ingen indbetalinger!
       <th align=left>Dato og tidspunkt</th>
       <th align=left>Produkt</th>
       <th align=left>Pris</th>
+      <th align=left>Tilbagefør</th>
    </tr>
 {% autoescape off %}
 {% for sale in last_sale_list %}
@@ -46,6 +47,15 @@ Ingen indbetalinger!
       <td>{{sale.timestamp}}</td>
       <td>{{sale.product.name}}</td>
       <td align="right">{{sale.price|money}}</td>
+      <td>
+         {% if sale.is_reimbursable %}
+         <form action="" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="sale_id" value="{{ sale.pk }}"/>
+            <button name="action" value="reimburse" onclick="return confirm('Er du sikker på at du vil refundere salget på {{sale.product.name}} til en værdi af {{sale.price|money}} kr?')">Undo</button>
+         </form>
+         {% endif %}
+      </td>
    </tr>
 {% endfor %}
 {% endautoescape %}

--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -23,7 +23,8 @@ from stregsystem.models import (
     Product,
     Room,
     Sale,
-    StregForbudError
+    StregForbudError,
+    Reimbursement
 )
 from stregsystem.utils import (
     make_active_productlist_query,
@@ -179,11 +180,14 @@ def usermenu(request, room, member, bought, from_sale=False):
 def menu_userinfo(request, room_id, member_id):
     room = Room.objects.get(pk=room_id)
     news = __get_news()
+
+    if request.method == 'POST':
+        Reimbursement.from_sale(request.POST['sale_id'])
     member = Member.objects.get(pk=member_id, active=True)
 
-    last_sale_list = member.sale_set.order_by('-timestamp')[:10]
+    last_sale_list = member.sale_set.filter(is_reimbursed=False).order_by('-timestamp')[:10]
     try:
-        last_payment = member.payment_set.order_by('-timestamp')[0]
+        last_payment = member.payment_set.filter(is_reimbursement=False).order_by('-timestamp')[0]
     except IndexError:
         last_payment = None
 


### PR DESCRIPTION
This is an initial fix for #188.

This PR allows the user to refund his/her purchase by doing the following:
Modifies the sale to show `is_reimbursed`.
Creates a new payment for the amount that the sale was on. This payment is tagged with `is_reimbursement`.
The button for reimbursing the user is on the user information. The user only sees sales that have not been reimbursed. 
Example:
![image](https://user-images.githubusercontent.com/5766695/95626949-94490280-0a7b-11eb-9707-f704199fdf9d.png)
[Example of confirmation dialog](https://user-images.githubusercontent.com/5766695/95626957-9b701080-0a7b-11eb-9839-479afe469605.png)


The button is only visible to the user if the sale was within the last 12 hours.
Unfortunately I had to allow the user to edit a sale. This may be unwanted - but I could not think of another way to do this.

The reason for modifying the sale is to allow the values to be filtered out of statistics.

Questions I had during making this:
Should the "Undo" button be an actual button or rather an anchor?
Should I have instead of creating a `Payment`, instead save `Refund` in a separate table?

I hope for feedback.

Also I need tests. Lots of tests...