### PR TITLE
Update url to re_path in Django URL patterns

### DIFF
--- a/kiosk/urls.py
+++ b/kiosk/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.kiosk),
-    url(r'^random$', views.find_random_media),
-    url(r'^next_real/(?P<item_id>\d+)/$', views.find_next_media_real),
+    re_path(r'^$', views.kiosk),
+    re_path(r'^random$', views.find_random_media),
+    re_path(r'^next_real/(?P<item_id>\d+)/$', views.find_next_media_real),
 ]

--- a/stregreport/urls.py
+++ b/stregreport/urls.py
@@ -1,39 +1,39 @@
 """stregsystem URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+    https://docs.djangoproject.com/en/2.2/ref/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 from .models import BreadRazzia
 
 urlpatterns = [
-    url(r'^admin/stregsystem/razzia/bread/(?P<razzia_id>\d+)/$', views.razzia, {'razzia_type' : BreadRazzia.BREAD, 'title': 'Brødrazzia'}, name="bread_view"),
-    url(r'^admin/stregsystem/razzia/foobar/(?P<razzia_id>\d+)/$', views.razzia, {'razzia_type' : BreadRazzia.FOOBAR, 'title': 'Foobar razzia'}, name="foobar_view"),
-    url(r'^admin/stregsystem/razzia/bread/(?P<razzia_id>\d+)/members$', views.razzia_members, {'razzia_type' : BreadRazzia.BREAD, 'title': 'Brødrazzia'}),
-    url(r'^admin/stregsystem/razzia/foobar/(?P<razzia_id>\d+)/members$', views.razzia_members, {'razzia_type' : BreadRazzia.FOOBAR, 'title': 'Foobar razzia'}),
-    url(r'^admin/stregsystem/razzia/bread/$', views.razzia_menu, {'razzia_type' : BreadRazzia.BREAD, 'new_text': "New bread razzia", 'title': 'Brødrazzia'}),
-    url(r'^admin/stregsystem/razzia/foobar/$', views.razzia_menu, {'razzia_type' : BreadRazzia.FOOBAR, 'new_text': "New foobar razzia", 'title': 'Foobar razzia'}),
-    url(r'^admin/stregsystem/razzia/bread/new$', views.new_razzia, {'razzia_type' : BreadRazzia.BREAD}, name="razzia_new_BR"),
-    url(r'^admin/stregsystem/razzia/foobar/new$', views.new_razzia, {'razzia_type' : BreadRazzia.FOOBAR}, name="razzia_new_FB"),
-    url(r'^admin/stregsystem/razzia/wizard_guide/$', views.razzia_wizard),
-    url(r'^admin/stregsystem/razzia/wizard/$', views.razzia_view, name="razzia_view"),
-    url(r'^admin/stregsystem/report/sales/$', views.sales, name="salesreporting"),
-    url(r'^admin/stregsystem/report/ranks/$', views.ranks),
-    url(r'^admin/stregsystem/report/daily/$', views.daily),
-    url(r'^admin/stregsystem/report/ranks/(?P<year>\d+)$', views.ranks),
-    url(r'^admin/stregsystem/report/$', views.reports),
-    url(r'^admin/stregsystem/report/sales_api$', views.sales_api),
-    url(r'^admin/stregsystem/report/categories/$', views.user_purchases_in_categories),
+    re_path(r'^admin/stregsystem/razzia/bread/(?P<razzia_id>\d+)/$', views.razzia, {'razzia_type' : BreadRazzia.BREAD, 'title': 'Brødrazzia'}, name="bread_view"),
+    re_path(r'^admin/stregsystem/razzia/foobar/(?P<razzia_id>\d+)/$', views.razzia, {'razzia_type' : BreadRazzia.FOOBAR, 'title': 'Foobar razzia'}, name="foobar_view"),
+    re_path(r'^admin/stregsystem/razzia/bread/(?P<razzia_id>\d+)/members$', views.razzia_members, {'razzia_type' : BreadRazzia.BREAD, 'title': 'Brødrazzia'}),
+    re_path(r'^admin/stregsystem/razzia/foobar/(?P<razzia_id>\d+)/members$', views.razzia_members, {'razzia_type' : BreadRazzia.FOOBAR, 'title': 'Foobar razzia'}),
+    re_path(r'^admin/stregsystem/razzia/bread/$', views.razzia_menu, {'razzia_type' : BreadRazzia.BREAD, 'new_text': "New bread razzia", 'title': 'Brødrazzia'}),
+    re_path(r'^admin/stregsystem/razzia/foobar/$', views.razzia_menu, {'razzia_type' : BreadRazzia.FOOBAR, 'new_text': "New foobar razzia", 'title': 'Foobar razzia'}),
+    re_path(r'^admin/stregsystem/razzia/bread/new$', views.new_razzia, {'razzia_type' : BreadRazzia.BREAD}, name="razzia_new_BR"),
+    re_path(r'^admin/stregsystem/razzia/foobar/new$', views.new_razzia, {'razzia_type' : BreadRazzia.FOOBAR}, name="razzia_new_FB"),
+    re_path(r'^admin/stregsystem/razzia/wizard_guide/$', views.razzia_wizard),
+    re_path(r'^admin/stregsystem/razzia/wizard/$', views.razzia_view, name="razzia_view"),
+    re_path(r'^admin/stregsystem/report/sales/$', views.sales, name="salesreporting"),
+    re_path(r'^admin/stregsystem/report/ranks/$', views.ranks),
+    re_path(r'^admin/stregsystem/report/daily/$', views.daily),
+    re_path(r'^admin/stregsystem/report/ranks/(?P<year>\d+)$', views.ranks),
+    re_path(r'^admin/stregsystem/report/$', views.reports),
+    re_path(r'^admin/stregsystem/report/sales_api$', views.sales_api),
+    re_path(r'^admin/stregsystem/report/categories/$', views.user_purchases_in_categories),
 ]

--- a/stregsystem/urls.py
+++ b/stregsystem/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, re_path
 
 from . import views
 from django.shortcuts import redirect
@@ -6,27 +6,27 @@ from django.shortcuts import redirect
 """stregsystem URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+    https://docs.djangoproject.com/en/2.2/ref/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
 urlpatterns = [
-    url(r'^$', views.roomindex, name="index"),
-    url(r'^admin/batch/$', views.batch_payment, name="batch"),
-    url(r'^admin/mobilepaytool/$', views.mobilepaytool, name="mobilepaytool"),
-    url(r'^(?P<room_id>\d+)/$', views.index, name="menu_index"),
-    url(r'^(?P<room_id>\d+)/sale/$', views.sale, name="quickbuy"),
-    url(r'^(?P<room_id>\d+)/sale/(?P<member_id>\d+)/$', views.menu_sale, name="menu"),
-    url(r'^(?P<room_id>\d+)/sale/\d+/\d+/$', lambda request, room_id: redirect('menu_index', room_id=room_id), name="menu_sale"),
-    url(r'^(?P<room_id>\d+)/user/(?P<member_id>\d+)/$', views.menu_userinfo, name="userinfo"),
-    url(r'^(?P<room_id>\d+)/user/(?P<member_id>\d+)/pay$', views.menu_userpay, name="userpay"),
-    url(r'^api/member/payment/qr$', views.qr_payment, name="payment_qr"),
+    re_path(r'^$', views.roomindex, name="index"),
+    re_path(r'^admin/batch/$', views.batch_payment, name="batch"),
+    re_path(r'^admin/mobilepaytool/$', views.mobilepaytool, name="mobilepaytool"),
+    re_path(r'^(?P<room_id>\d+)/$', views.index, name="menu_index"),
+    re_path(r'^(?P<room_id>\d+)/sale/$', views.sale, name="quickbuy"),
+    re_path(r'^(?P<room_id>\d+)/sale/(?P<member_id>\d+)/$', views.menu_sale, name="menu"),
+    re_path(r'^(?P<room_id>\d+)/sale/\d+/\d+/$', lambda request, room_id: redirect('menu_index', room_id=room_id), name="menu_sale"),
+    re_path(r'^(?P<room_id>\d+)/user/(?P<member_id>\d+)/$', views.menu_userinfo, name="userinfo"),
+    re_path(r'^(?P<room_id>\d+)/user/(?P<member_id>\d+)/pay$', views.menu_userpay, name="userpay"),
+    re_path(r'^api/member/payment/qr$', views.qr_payment, name="payment_qr"),
 ]

--- a/treo/urls.py
+++ b/treo/urls.py
@@ -1,31 +1,31 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.conf.urls.static import static
 from django.contrib import admin
 
 """stregsystem URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+    https://docs.djangoproject.com/en/2.2/ref/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
 
 urlpatterns = [
-    url(r'^', include("stregsystem.urls")),
-    url(r'^', include("stregreport.urls")),
-    url(r'^kiosk/', include("kiosk.urls")),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^', include("stregsystem.urls")),
+    re_path(r'^', include("stregreport.urls")),
+    re_path(r'^kiosk/', include("kiosk.urls")),
+    re_path(r'^admin/', admin.site.urls),
 
-    url(r'^select2/', include('django_select2.urls')),
+    re_path(r'^select2/', include('django_select2.urls')),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
@@ -33,5 +33,5 @@ urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns = [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns


### PR DESCRIPTION
url is an alias to re_path, and url is likely to be deprecated in the future according to the Django docs.