### PR TITLE
Add 'total sales monthly' reporting feature for treasurer

### DIFF
--- a/stregsystem/templates/admin/stregsystem/report/total_sales_monthly.html
+++ b/stregsystem/templates/admin/stregsystem/report/total_sales_monthly.html
@@ -1,0 +1,37 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block title %}Total sales monthly{% endblock %}
+{% block breadcrumbs %}
+    <div class="breadcrumbs"><a href="../..">Hjem</a></div>{% endblock %}
+
+{% block content %}
+    {% load admin_static %}
+
+    <h1>Total sales monthly</h1>
+    <p>Table showing total registered sales during a given month in the past year. Useful for the treasurer for
+        bookkeeping.</p>
+    <table>
+        <thead>
+        <tr>
+            <th>Year</th>
+            <th>Month</th>
+            <th>DKK</th>
+        </tr>
+        </thead>
+        <tr></tr>
+        {% for m in total_sales_monthly %}
+            <tr>
+                <td>
+                    {{ m.0 }}
+                </td>
+                <td>
+                    {{ m.1 }}
+                </td>
+                <td>
+                    {{ m.2 }}
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endblock %}

--- a/stregsystem/templates/admin/stregsystem/report/total_sales_monthly.html
+++ b/stregsystem/templates/admin/stregsystem/report/total_sales_monthly.html
@@ -20,16 +20,16 @@
         </tr>
         </thead>
         <tr></tr>
-        {% for m in total_sales_monthly %}
+        {% for entry in total_sales_monthly %}
             <tr>
                 <td>
-                    {{ m.0 }}
+                    {{ entry.year }}
                 </td>
                 <td>
-                    {{ m.1 }}
+                    {{ entry.month }}
                 </td>
                 <td>
-                    {{ m.2 }}
+                    {{ entry.sales_amount }}
                 </td>
             </tr>
         {% endfor %}

--- a/stregsystem/templates/shared_report_lists.html
+++ b/stregsystem/templates/shared_report_lists.html
@@ -25,6 +25,11 @@
             <td>&nbsp;</td>
             <td>&nbsp;</td>
         </tr>
+        <tr>
+            <th scope="row"><a href = "/admin/totalsales/">Total sales monthly</a></th>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+        </tr>
     </table>
 </div>
 

--- a/stregsystem/urls.py
+++ b/stregsystem/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     re_path(r'^$', views.roomindex, name="index"),
     re_path(r'^admin/batch/$', views.batch_payment, name="batch"),
     re_path(r'^admin/mobilepaytool/$', views.mobilepaytool, name="mobilepaytool"),
+    re_path(r'^admin/totalsales/$', views.total_sales_monthly, name="total_monthly_sales"),
     re_path(r'^(?P<room_id>\d+)/$', views.index, name="menu_index"),
     re_path(r'^(?P<room_id>\d+)/sale/$', views.sale, name="quickbuy"),
     re_path(r'^(?P<room_id>\d+)/sale/(?P<member_id>\d+)/$', views.menu_sale, name="menu"),

--- a/stregsystem/utils.py
+++ b/stregsystem/utils.py
@@ -97,6 +97,21 @@ def make_unprocessed_member_filled_mobilepayment_query():
         Q(payment__isnull=True) & Q(status=MobilePayment.UNSET) & Q(member__isnull=False))
 
 
+def total_sales_monthly_query(month_year_pair):
+    """
+    Generates list of tuples (year, month, sum of sales for that month) given an input list of tuples (month, year)
+    """
+    from django.db.models import Sum
+    from stregsystem.templatetags.stregsystem_extras import money
+    from stregsystem.models import Sale
+    import datetime
+
+    res = list()
+    for m, y in month_year_pair:
+        res.append((y, m, money(
+            Sale.objects.filter(timestamp__month=m, timestamp__year=y).aggregate(Sum('price'))['price__sum'])))
+    return res
+
 def date_to_midnight(date):
     """
     Converts a datetime.date to a datetime of the same date at midnight.

--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -6,7 +6,7 @@ from django.forms import modelformset_factory, formset_factory
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import permission_required
 from django.conf import settings
-from django.db.models import Q, Sum
+from django.db.models import Q
 from django import forms
 from django.http import HttpResponsePermanentRedirect, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render

--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -1,3 +1,4 @@
+import calendar
 import datetime
 
 from django.core import management
@@ -394,7 +395,8 @@ def total_sales_monthly(request):
     months = [((m + current_month) % 12 + 1, last_year + (m + current_month) // 12) for m in range(0, 12)]
 
     # for each month, year pair, sum all sales in that period, and convert numeric month to text
-    data['total_sales_monthly'] = [(y, datetime.date(1970, m, 1).strftime('%B'), p) for y, m, p in
-                                   total_sales_monthly_query(months)]
+    data['total_sales_monthly'] = list()
+    for y, m, total in total_sales_monthly_query(months):
+        data['total_sales_monthly'].append({'year': y, 'month': calendar.month_name[m], 'sales_amount': total})
 
     return render(request, "admin/stregsystem/report/total_sales_monthly.html", data)


### PR DESCRIPTION
During this years VAT bookkeeping it was found that there was no easy way for non-FIT members to look up total sales for any given month. This PR adds that statistic for each of the past 12 months. 

The feature could be extended to allow users to pick any month they like but I chose not to implement that since dealing with time sucks. For the purposes of the treasurer this is more than sufficient for monthly bookkeeping and the yearly bookkeeping associated with paying VAT.

Generates a table viewable only by staff-members:
![image](https://user-images.githubusercontent.com/11318702/109425202-79a20680-79e7-11eb-8952-5e1ed82c7c8c.png)
