### PR TITLE
Ignore less than 50.00 DKK in AutoPayment

### DIFF
--- a/stregsystem/models.py
+++ b/stregsystem/models.py
@@ -431,7 +431,6 @@ class MobilePayment(models.Model):
                 # Save payment and foreign key to MobilePayment field
                 payment.save()
                 payment.log_from_mobile_payment(processed_mobile_payment, admin_user)
-                processed_mobile_payment.log_mobile_payment(admin_user, "Approved")
                 processed_mobile_payment.payment = payment
                 processed_mobile_payment.save()
 

--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -1585,8 +1585,8 @@ class AutoPaymentTests(TestCase):
         MobilePayment.approve_member_filled_mobile_payments()
         MobilePayment.submit_processed_mobile_payments(self.autopayment_user)
 
-        ignored = MobilePayment.objects.get(transaction_id='156E027485173228')
-        self.assertEqual(ignored.status, MobilePayment.UNSET)
+        unset = MobilePayment.objects.get(transaction_id='156E027485173228')
+        self.assertEqual(unset.status, MobilePayment.UNSET)
 
     def test_ignore_lt_50_49(self):
         comment = 'tester'

--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -1601,8 +1601,8 @@ class AutoPaymentTests(TestCase):
         MobilePayment.approve_member_filled_mobile_payments()
         MobilePayment.submit_processed_mobile_payments(self.autopayment_user)
 
-        ignored = MobilePayment.objects.get(transaction_id='156E027485173228')
-        self.assertEqual(ignored.status, MobilePayment.UNSET)
+        unset = MobilePayment.objects.get(transaction_id='156E027485173228')
+        self.assertEqual(unset.status, MobilePayment.UNSET)
 
     def test_approve_gte_50(self):
         comment = 'tester'

--- a/stregsystem/utils.py
+++ b/stregsystem/utils.py
@@ -79,7 +79,7 @@ def make_unprocessed_member_filled_mobilepayment_query() -> QuerySet:
     from stregsystem.models import MobilePayment  # import locally to avoid circular import
 
     return MobilePayment.objects.filter(
-        Q(payment__isnull=True) & Q(status=MobilePayment.UNSET) & Q(member__isnull=False)
+        Q(payment__isnull=True) & Q(status=MobilePayment.UNSET) & Q(amount__gte=5000) & Q(member__isnull=False)
     )
 
 


### PR DESCRIPTION
This PR stops AutoPayment from automatically accepting less than 50.00 DKK MobilePayments.
This is to encourage members to deposit more than 49.99 DKK to minimize the amount of transactionsfees in MobilePay.

Additionally this PR also removes the "Approved" logentry for a MobilePayment.
This is to lessen the spam in the logentries. The entry is already logged when there is created a new payment entry.
In the image below, the top element would be removed.
![image](https://user-images.githubusercontent.com/5766695/168904243-aa1ee582-158a-4591-bcd9-5e91c6d15e32.png)

