### PR TITLE
Prevent bats/flakes from overlapping QR-codes

### DIFF
--- a/stregsystem/static/stregsystem/stregsystem.css
+++ b/stregsystem/static/stregsystem/stregsystem.css
@@ -133,3 +133,9 @@ table h2, table h3 {
       -webkit-transform: scale(1,1) translate(0, -2px) rotate(.2deg);
   }
 }
+
+/* Ensures that bats/"flakes" don't interfere with qr-code scanning */
+.qr-code {
+    position: relative;
+    z-index: 2147483647;
+}

--- a/stregsystem/templates/stregsystem/mobilepay_qr.html
+++ b/stregsystem/templates/stregsystem/mobilepay_qr.html
@@ -1,5 +1,5 @@
 {% if amount %}
-<img width="300" height="300" src="/api/member/payment/qr?member={{username | urlencode}}&amount={{amount | floatformat | urlencode}}" />
+<img width="300" height="300" src="/api/member/payment/qr?member={{username | urlencode}}&amount={{amount | floatformat | urlencode}}" class="qr-code"/>
 {% else %}
-<img width="300" height="300" src="/api/member/payment/qr?member={{username | urlencode}}" />
+<img width="300" height="300" src="/api/member/payment/qr?member={{username | urlencode}}" class="qr-code"/>
 {% endif %}


### PR DESCRIPTION
Addresses issues #303.

- Sets relative positioning and z-index of QR-codes on the user/pay page.
- Tested for bats, beerflakes, and snowflakes.