### PR TITLE
Upgrade HTML doctype in stregsystem

### DIFF
--- a/stregsystem/templates/500.html
+++ b/stregsystem/templates/500.html
@@ -1,15 +1,10 @@
 {% load static %}
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="da-DK">
 <head>
 <title>{% block title %}TREOENs STREGSYSTEM{% endblock %}</title>
-<link rel="stylesheet" type="text/css" media="screen" href="{% static "/stregsystem/stregsystem.css" %}" />
-<style type="text/css">
-
-</style>
-<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" media="screen" href="{% static "/stregsystem/stregsystem.css" %}">
 </head>
 <body>
 {% comment %}
@@ -18,7 +13,7 @@
 {% endcomment %}
 
 <h1>Der er desv&aelig;rre sket en fejl i stregsystemet!</h1>
-Fejlen er blevet logget, og vil blive fixet over tid...<br />
+Fejlen er blevet logget, og vil blive fixet over tid...<br>
 
 <h3>Brug tilbage linket her, for at komme tilbage: <a href="javascript:history.back()">Tilbage</a></h3>
 

--- a/stregsystem/templates/stregsystem/base.html
+++ b/stregsystem/templates/stregsystem/base.html
@@ -1,19 +1,14 @@
 {% load static %}
 {% load stregsystem_extras %}
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="da-DK">
 <head>
 <title>{% block title %}TREOENs STREGSYSTEM{% endblock %}</title>
-<link rel="stylesheet" type="text/css" media="screen" href="{% static "/stregsystem/stregsystem.css" %}" />
-<style type="text/css">
-
-</style>
-<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-<link rel="stylesheet" type="text/css" media="screen" href="{% static "/stregsystem/bat.css" %}" />
-<link rel="stylesheet" type="text/css" media="screen" href="{% static "/stregsystem/snow.css" %}" />
-<link rel="stylesheet" type="text/css" media="screen" href="{% static "/stregsystem/easter.css" %}" />
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" media="screen" href="{% static "/stregsystem/stregsystem.css" %}">
+<link rel="stylesheet" media="screen" href="{% static "/stregsystem/bat.css" %}">
+<link rel="stylesheet" media="screen" href="{% static "/stregsystem/snow.css" %}">
+<link rel="stylesheet" media="screen" href="{% static "/stregsystem/easter.css" %}">
 <script>
     var static_url = "{% get_static_prefix %}";
     var media_url = "{% get_media_prefix %}";
@@ -29,7 +24,7 @@
     <tr>
         <td>
           <center>
-            <input type="button" onclick="location.href='/{{room.id}}';" value="Genstart" tabindex="10" accesskey="q" />
+            <input type="button" onclick="location.href='/{{room.id}}';" value="Genstart" tabindex="10" accesskey="q">
           </center>
         </td>
         <td align=center>
@@ -41,16 +36,16 @@
         </td>
         <td>
           <center>
-            <input type="button" onclick="location.href='/{{room.id}}';" value="Menu" tabindex="11" />
+            <input type="button" onclick="location.href='/{{room.id}}';" value="Menu" tabindex="11">
           </center>
         </td>
     </tr>
 </table>
-<hr />
+<hr>
 
 {% block content %}{% endblock %}
 
-<hr />
+<hr>
 
 <div id="news">
 {% block news %}
@@ -59,10 +54,10 @@
 {% endif %}
 {% endblock %}
 </div>
-<script type="text/javascript" async src="{% static "/stregsystem/bat.js" %}"></script>
-<script type="text/javascript" async src="{% static "/stregsystem/snow.js" %}"></script>
-<script type="text/javascript" async src="{% static "/stregsystem/easter.js" %}"></script>
-<script type="text/javascript" async src="{% static "/stregsystem/gdpr.js" %}"></script>
+<script async src="{% static "/stregsystem/bat.js" %}"></script>
+<script async src="{% static "/stregsystem/snow.js" %}"></script>
+<script async src="{% static "/stregsystem/easter.js" %}"></script>
+<script async src="{% static "/stregsystem/gdpr.js" %}"></script>
 <div class="bat-container"></div>
 <div class="snow-container"></div>
 <div class="easter-container"></div>


### PR DESCRIPTION
Browser engineers have spent the last 10 years writing speed optimizations for HTML. Those optimizations are all disabled for the stregsystem because it still uses the old XHTML 1.1 doctype.

Updating to HTML 5 could make the interface run noticeably faster on the cpu-constrained raspi/pos-thing that hosts the stregsystem interface at strandvejen.

I have tested this change and everything seems to work. I also don't see why anything should break from it.