### PR TITLE
Include chosen date in rank

### DIFF
--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -307,7 +307,7 @@ def menu_userrank(request, room_id, member_id):
         form = RankingDateForm(request.POST)
         if form.is_valid():
             from_date = form.cleaned_data['from_date']
-            to_date = form.cleaned_data['to_date']
+            to_date = form.cleaned_data['to_date'] + datetime.timedelta(days=1)
     else:
         # setup initial dates for form and results
         form = RankingDateForm(initial={'from_date': from_date, 'to_date': to_date})


### PR DESCRIPTION
When accessing the user rankings, the statistics does not include the date specified in the "To" date field. 

This PR makes sure that the "to_date" includes the specified date.