### PR TITLE
Add limit and frontend fluff for foobar check-ins within the hour

### DIFF
--- a/stregreport/views.py
+++ b/stregreport/views.py
@@ -58,10 +58,21 @@ def razzia_view_single(request, razzia_id, queryname, razzia_type=BreadRazzia.BR
         if len(result) > 0:
             member = result[0]
             entries = list(razzia.razziaentry_set.filter(member__pk=member.pk).order_by('-time'))
-            already_used = len(entries) > 0
-            if already_used:
-                entry = entries[0]
-            if not already_used or razzia_type == BreadRazzia.FOOBAR:
+            already_checked_in = len(entries) > 0
+            if already_checked_in:
+                last_entry = entries[0]
+                within_the_hour = last_entry.time > timezone.now() - datetime.timedelta(hours=1)
+            # if member has already checked in within the last hour, don't allow another check in
+            if already_checked_in and within_the_hour:
+                drunkard = True
+                # time until next check in is legal
+                remaining_time_secs = int(
+                    ((last_entry.time + datetime.timedelta(hours=1)) - timezone.now()).total_seconds() % 60
+                )
+                remaining_time_mins = int(
+                    ((last_entry.time + datetime.timedelta(hours=1)) - timezone.now()).total_seconds() // 60
+                )
+            if not already_checked_in or razzia_type == BreadRazzia.FOOBAR and not within_the_hour:
                 RazziaEntry(member=member, razzia=razzia).save()
 
     templates = {

--- a/stregreport/views.py
+++ b/stregreport/views.py
@@ -67,12 +67,8 @@ def razzia_view_single(request, razzia_id, queryname, razzia_type=BreadRazzia.BR
             if already_checked_in and within_wait and razzia_type == BreadRazzia.FOOBAR:
                 drunkard = True
                 # time until next check in is legal
-                remaining_time_secs = int(
-                    ((last_entry.time + wait_time) - timezone.now()).total_seconds() % 60
-                )
-                remaining_time_mins = int(
-                    ((last_entry.time + wait_time) - timezone.now()).total_seconds() // 60
-                )
+                remaining_time_secs = int(((last_entry.time + wait_time) - timezone.now()).total_seconds() % 60)
+                remaining_time_mins = int(((last_entry.time + wait_time) - timezone.now()).total_seconds() // 60)
             if not already_checked_in or (razzia_type == BreadRazzia.FOOBAR and not within_wait):
                 RazziaEntry(member=member, razzia=razzia).save()
 

--- a/stregreport/views.py
+++ b/stregreport/views.py
@@ -59,20 +59,21 @@ def razzia_view_single(request, razzia_id, queryname, razzia_type=BreadRazzia.BR
             member = result[0]
             entries = list(razzia.razziaentry_set.filter(member__pk=member.pk).order_by('-time'))
             already_checked_in = len(entries) > 0
+            wait_time = datetime.timedelta(minutes=30)
             if already_checked_in:
                 last_entry = entries[0]
-                within_the_hour = last_entry.time > timezone.now() - datetime.timedelta(hours=1)
+                within_wait = last_entry.time > timezone.now() - wait_time
             # if member has already checked in within the last hour, don't allow another check in
-            if already_checked_in and within_the_hour:
+            if already_checked_in and within_wait and razzia_type == BreadRazzia.FOOBAR:
                 drunkard = True
                 # time until next check in is legal
                 remaining_time_secs = int(
-                    ((last_entry.time + datetime.timedelta(hours=1)) - timezone.now()).total_seconds() % 60
+                    ((last_entry.time + wait_time) - timezone.now()).total_seconds() % 60
                 )
                 remaining_time_mins = int(
-                    ((last_entry.time + datetime.timedelta(hours=1)) - timezone.now()).total_seconds() // 60
+                    ((last_entry.time + wait_time) - timezone.now()).total_seconds() // 60
                 )
-            if not already_checked_in or razzia_type == BreadRazzia.FOOBAR and not within_the_hour:
+            if not already_checked_in or (razzia_type == BreadRazzia.FOOBAR and not within_wait):
                 RazziaEntry(member=member, razzia=razzia).save()
 
     templates = {

--- a/stregsystem/templates/admin/stregsystem/razzia/bread.html
+++ b/stregsystem/templates/admin/stregsystem/razzia/bread.html
@@ -4,7 +4,7 @@
 
 {% block member_present %}
 <div class="status">
-	<div class="fa {% if already_used %} fa-minus-circle failure {% else %} fa-check-circle sucess {% endif %}" aria-hidden="true"></div>
+	<div class="fa {% if already_checked_in %} fa-minus-circle failure {% else %} fa-check-circle sucess {% endif %}" aria-hidden="true"></div>
 </div>
-{{member.firstname}} {{member.lastname}} ({{member.username}}) {% if already_used %} already checked in at {{ entry.time }} {% endif %}
+{{member.firstname}} {{member.lastname}} ({{member.username}}) {% if already_checked_in %} already checked in at {{ last_entry.time }} {% endif %}
 {% endblock %}

--- a/stregsystem/templates/admin/stregsystem/razzia/foobar.html
+++ b/stregsystem/templates/admin/stregsystem/razzia/foobar.html
@@ -4,7 +4,31 @@
 
 {% block member_present %}
 <div class="status">
-	<div class="fa {% if already_used %} fa-exclamation-circle sucess {% else %} fa-check-circle sucess {% endif %}" aria-hidden="true"></div>
+    {% if drunkard %}
+            <script>
+                // fade/flash background color to more easily notify foobar crew
+                let ofs = 0;
+                let el = document.body;
+                window.setInterval(function(){
+                  el.style.background = 'rgba(255,255,0,'+Math.abs(Math.sin(ofs))+')';
+                  ofs += 0.02;
+                }, 10);
+            </script>
+        <div class="fa fa-exclamation-triangle failure" aria-hidden="true"></div>
+	{% else %}
+        <div class="fa {% if already_used %} fa-exclamation-circle sucess {% else %} fa-check-circle sucess {% endif %}" aria-hidden="true"></div>
+    {% endif %}
 </div>
-{{member.firstname}} {{member.lastname}} ({{member.username}}) {% if already_used %} last checked in at {{entry.time}} {% endif %}
+{% if drunkard %}
+    {{member.firstname}} {{member.lastname}} ({{member.username}}) <b>wait {{ remaining_time_mins }}m {{ remaining_time_secs }}s </b> before next free beer
+{% else %}
+    {{member.firstname}} {{member.lastname}} ({{member.username}}) {% if already_checked_in %} last checked in at {{last_entry.time}} {% endif %}
+{% endif %}
+
 {% endblock %}
+
+{% block drunkard_present %}
+    fa-exclamation-triangle
+    {% if drunkard %} checked in within the previous hour, wait {{ remaining_time }}{% endif %}
+{% endblock %}
+


### PR DESCRIPTION
Required for foobar on Friday to mitigate unreasonable waste of free beer. Limit is 0.5L beer/hour, where average consumption over the entire event is ~1.3L beer.