### PR TITLE
Added CORS middleware

### DIFF
--- a/stregsystem/middleware.py
+++ b/stregsystem/middleware.py
@@ -1,0 +1,41 @@
+from django import http
+from django.core.handlers.wsgi import WSGIRequest
+
+
+class CorsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, req):
+        req_headers = req
+        if isinstance(req, WSGIRequest):
+            req_headers = req.headers
+
+        if req.method == 'OPTIONS' and "access-control-request-method" in req_headers:
+            return self.handle_preflight(req)
+
+        res = self.get_response(req)
+
+        # Allow cookies to be sent for CORS requests
+        res['access-control-allow-credentials'] = 'true'
+        CorsMiddleware.set_origin_access(req_headers, res)
+
+        return res
+
+    @staticmethod
+    def set_origin_access(req, res):
+        res['vary'] = 'Origin'
+        if 'origin' in req:
+            res['access-control-allow-origin'] = req['origin']
+        else:
+            res['access-control-allow-origin'] = '*'
+
+    @staticmethod
+    def handle_preflight(req):
+        res = http.HttpResponse()
+
+        CorsMiddleware.set_origin_access(req, res)
+        res['access-control-allow-methods'] = 'POST, GET, OPTIONS, DELETE'
+        res['access-control-max-age'] = '86400'
+
+        return res

--- a/treo/settings.py
+++ b/treo/settings.py
@@ -104,6 +104,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'stregsystem.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
This PR adds a Django middleware that handles CORS requests. This allows CORS compliant clients (primarily web browsers) to access exposed API endpoints. The PR is primarily aimed at granting the access necessary for fappen to work.

- Handles CORS preflight requests
  - Allows all normal headers (permissions set to `*`)
  - Allows methods: `POST, GET, OPTIONS, DELETE`
- Sets allowed origins to:
  - the request origin if given
  - `*` if origin is unknown
- Allows requests to contain credentials (cookies)