### PR TITLE
Fix spelling and remove redundant code

### DIFF
--- a/stregsystem/admin.py
+++ b/stregsystem/admin.py
@@ -84,14 +84,16 @@ class SaleAdmin(admin.ModelAdmin):
     get_price_display.short_description = "Price"
     get_price_display.admin_order_field = "price"
 
-    def refund(modeladmin, request, queryset):
-        for obj in queryset:
-            transaction = PayTransaction(obj.price)
-            obj.member.rollback(transaction)
-            obj.member.save()
-        queryset.delete()
 
-    refund.short_description = "Refund selected"
+def refund(modeladmin, request, queryset):
+    for obj in queryset:
+        transaction = PayTransaction(obj.price)
+        obj.member.rollback(transaction)
+        obj.member.save()
+    queryset.delete()
+
+
+refund.short_description = "Refund selected"
 
 
 def toggle_active_selected_products(modeladmin, request, queryset):

--- a/stregsystem/booze.py
+++ b/stregsystem/booze.py
@@ -50,7 +50,7 @@ def alcohol_bac_timeline(gender, weight, now, alcohol_timeline):
     last_time = None
     for time, ml in alcohol_timeline:
         # First iteration has BAC 0, and a BAC of 0 can't degrade, so the first
-        # iteration doesn't need degredation
+        # iteration doesn't need degradation
         if last_time is not None:
             time_diff = time - last_time
             current -= alcohol_bac_degradation(time_diff)
@@ -69,7 +69,7 @@ def alcohol_bac_timeline(gender, weight, now, alcohol_timeline):
     # Since we return if the list is empty we must have some last time
     assert last_time is not None
 
-    # We also need to remove the degredation from the last drink till now
+    # We also need to remove the degradation from the last drink till now
     time_diff = now - last_time
     current -= alcohol_bac_degradation(time_diff)
 

--- a/stregsystem/caffeine.py
+++ b/stregsystem/caffeine.py
@@ -47,7 +47,7 @@ def current_caffeine_in_body_compound_interest(intakes: List[Intake]) -> float:
             * ((1 - CAFFEINE_DEGRADATION_PR_HOUR) ** ((intake.timestamp - last_intake_time) / timedelta(hours=1))),
             0,
         )
-        # swap curr timestamp with last intake time to calculate degradation timespan in next iteration
+        # swap current timestamp with last intake time to calculate degradation timespan in next iteration
         last_intake_time = intake.timestamp
 
         # finally, add current intake of caffeine to mg_blood

--- a/stregsystem/templates/admin/stregsystem/report/sales.html
+++ b/stregsystem/templates/admin/stregsystem/report/sales.html
@@ -25,7 +25,7 @@
 	<input id="id_products" type="text" class="vTextField" name="products" maxlength="40" value="{{products}}" />
 	<input type="submit" value="Vis">
 	<br />
-	<label><small>Produkter sepereres med mellemrum eks: <i>11 32 14</i></small></label>
+	<label><small>Produkter separeres med mellemrum, f.eks: <i>11 32 14</i></small></label>
 	</form>
 	<br /><br />
 {% if sales %}

--- a/stregsystem/templates/mail/deposit_manual.html
+++ b/stregsystem/templates/mail/deposit_manual.html
@@ -15,7 +15,8 @@
             Hello {{ firstname }}!<br><br>
             We've had great trouble inserting {{ formatted_amount }} stregdollars on your account: "{{ username }}". <br><br>
             This is due to you not writing your username correctly, and instead writing '{{ mobilepay_comment }}'. The poor TREOs had to take multiple minutes out of their day to insert your money manually.
-            If you want to utilise our automatic fill-up in the future, you can write your username correctly in the MobilePay comment: '{{ username }}'
+            If you want to utilise our automatic fill-up in future, you can write your username correctly in the MobilePay comment: '{{ username }}'
+
             Our QR-code generator also handles this very complicated process for you. 
             
             If you do not desire to receive any more mails of this sort, please file a complaint to: <a href="mailto:treo@fklub.dk?Subject=Klage" target="_top">treo@fklub.dk</a><br><br>

--- a/stregsystem/templates/mail/deposit_manual.html
+++ b/stregsystem/templates/mail/deposit_manual.html
@@ -14,8 +14,8 @@
             ====================================================================<br>
             Hello {{ firstname }}!<br><br>
             We've had great trouble inserting {{ formatted_amount }} stregdollars on your account: "{{ username }}". <br><br>
-            This is due to you not you not writing your username correctly, and instead writing '{{ mobilepay_comment }}'. The poor TREOs had to take multiple minutes out of their day to insert your money manually.
-            If you want to utilise our automatic fill-up in future, you can write your username correctly in the MobilePay comment: '{{ username }}'
+            This is due to you not writing your username correctly, and instead writing '{{ mobilepay_comment }}'. The poor TREOs had to take multiple minutes out of their day to insert your money manually.
+            If you want to utilise our automatic fill-up in the future, you can write your username correctly in the MobilePay comment: '{{ username }}'
             Our QR-code generator also handles this very complicated process for you. 
             
             If you do not desire to receive any more mails of this sort, please file a complaint to: <a href="mailto:treo@fklub.dk?Subject=Klage" target="_top">treo@fklub.dk</a><br><br>

--- a/stregsystem/templates/mail/welcome.html
+++ b/stregsystem/templates/mail/welcome.html
@@ -5,7 +5,7 @@ Context is vars(member) and formatted_balance
     <head></head>
     <body>
         Hej {{ firstname }}!<br><br>
-        Velkommen som fember (medlem) i Fklubben!
+        Velkommen som fember (medlem) i F-klubben!
         Din stregkonto (bruger) er oprettet med følgende brugernavn: <b>{{ username }}</b>.<br>
         Fremover kan du benytte dit brugernavn i <a href="http://fklub.dk/treo/stregsystem">stregsystemet</a> til køb af diverse varer og/eller event billetter, såfremt du har penge på din stregkonto.<br>
         Din nuværende saldo er: {{ formatted_balance }} kr.<br><br>

--- a/stregsystem/templatetags/stregsystem_extras.py
+++ b/stregsystem/templatetags/stregsystem_extras.py
@@ -12,22 +12,16 @@ def caffeine_emoji_render(caffeine: int):
     return "☕" * caffeine_mg_to_coffee_cups(caffeine)
 
 
+@register.filter
 def money(value):
     if value is None:
         value = 0
     return "{0:.2f}".format(value / 100.0)
 
 
-register.filter('money', money)
-
-
 @register.inclusion_tag('stregsystem/adventcandle.html')
 def show_candle():
     return {'date': timezone.now()}
-
-
-t = get_template('stregsystem/adventcandle.html')
-register.inclusion_tag(t)(show_candle)
 
 
 @register.filter

--- a/stregsystem/utils.py
+++ b/stregsystem/utils.py
@@ -35,7 +35,7 @@ def make_active_productlist_query(queryset) -> QuerySet:
 
 def make_inactive_productlist_query(queryset) -> QuerySet:
     now = timezone.now()
-    # Create a query of things are definitively inactive. Some of the ones
+    # Create a query of things which are definitively inactive. Some of the ones
     # filtered here might be out of stock, but we include that later.
     inactive_candidates = queryset.exclude(
         Q(active=True) & (Q(deactivate_date=None) | Q(deactivate_date__gte=now))


### PR DESCRIPTION
 - Corrected a spelling error, and found a duplicated phrase in the mail and web-templates
 - Corrected spelling in a couple of comments, including one where the sentence didn't make much sense.
 - Refactored code to use decorators instead of explicit function calls below (haven't run any tests locally).
 - Changed the scope of an instance function without self keyword to that of a function with similar signature.