### PR TITLE
Fix preflight header for sale api

### DIFF
--- a/stregsystem/middleware.py
+++ b/stregsystem/middleware.py
@@ -36,6 +36,7 @@ class CorsMiddleware:
 
         CorsMiddleware.set_origin_access(req, res)
         res['access-control-allow-methods'] = 'POST, GET, OPTIONS, DELETE'
+        res['Access-Control-Allow-Headers'] = 'Content-type'
         res['access-control-max-age'] = '86400'
 
         return res

--- a/stregsystem/middleware.py
+++ b/stregsystem/middleware.py
@@ -36,7 +36,7 @@ class CorsMiddleware:
 
         CorsMiddleware.set_origin_access(req, res)
         res['access-control-allow-methods'] = 'POST, GET, OPTIONS, DELETE'
-        res['Access-Control-Allow-Headers'] = 'Content-type'
+        res['access-control-allow-headers'] = 'content-type'
         res['access-control-max-age'] = '86400'
 
         return res


### PR DESCRIPTION
This fixes the issue (https://github.com/f-klubben/fappen/issues/62) in fappen. 

The only real change is allowing for the use of the "content-type" header, which is required for sending JSON to the "sale" API endpoint.