### PR TITLE
Remove 'Regex' dependency (in favor of 'RE')

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Django==2.2.28
 Pillow==8.3.2
 Coverage==4.4.1
 pytz==2021.3
-regex==2017.07.28
 freezegun==0.3.15
 Django-Select2==5.11.1
 django-debug-toolbar==1.11.1

--- a/stregsystem/parser.py
+++ b/stregsystem/parser.py
@@ -1,4 +1,4 @@
-import regex
+import re
 
 
 class QuickBuyError(Exception):
@@ -11,7 +11,7 @@ class QuickBuyParseError(Exception):
     pass
 
 
-_item_matcher = regex.compile(r'(?V1)(?P<productId>\d+)(?::(?P<count>\d+))?$')
+_item_matcher = re.compile(r'(?P<productId>\d+)(?::(?P<count>\d+))?$')
 
 
 def get_token_indexes(string, start_index):


### PR DESCRIPTION
This dependency isn't needed as none of extra features it provides are in use. This will allow us to more easily update the python version in the future, as there would be fewer dependencies.

`(?V1)(?P<productId>\d+)(?::(?P<count>\d+))?$` has been changed into `(?P<productId>\d+)(?::(?P<count>\d+))?$`, the only change being removing the `(?V1)` flag which is 'regex'-specific simply making it parse it with version 1.0 parsing engine.