### PR TITLE
Fix division by zero error in heatmap

### DIFF
--- a/stregsystem/purchase_heatmap.py
+++ b/stregsystem/purchase_heatmap.py
@@ -79,7 +79,7 @@ class ItemCountHeatmapColorMode(HeatmapColorMode):
         super().__init__(mode_name="ItemCount", mode_description="Antal")
 
     def get_day_color(self, products: List[Product]) -> Tuple[int, int, int]:
-        if len(products) == 0:
+        if len(products) == 0 or self.max_items_day == 0:
             return 235, 237, 240  # Grey
 
         lerp_value = len(products) / self.max_items_day
@@ -107,7 +107,7 @@ class MoneySumHeatmapColorMode(HeatmapColorMode):
         super().__init__(mode_name="MoneySum", mode_description="Penge brugt")
 
     def get_day_color(self, products: List[Product]) -> Tuple[int, int, int]:
-        if len(products) == 0:
+        if len(products) == 0 or self.max_money_day_oere == 0:
             return 235, 237, 240  # Grey
 
         day_sum = sum(p.price for p in products)


### PR DESCRIPTION
Forgot to handle the case of a user only buying products which cost 0 F$.