### PR TITLE
Fix Buy button greyed out when navigating back from userrmenu

### DIFF
--- a/stregsystem/templates/stregsystem/index.html
+++ b/stregsystem/templates/stregsystem/index.html
@@ -98,6 +98,11 @@
 
 <div style="clear: both;">&nbsp;</div>
 
+<script>
+  window.addEventListener("pageshow", (event) => {
+    document.getElementById('buybutton').disabled = false;
+  });
+</script>
 
 {% endblock %}
 


### PR DESCRIPTION
Fixes #356

This adds an event listener to the index-page which reenables the buy button on 'pageshow'. Credit to @BoAnd for the fix in #356 