### PR TITLE
Add customer name to MobilePay tool

### DIFF
--- a/stregsystem/management/commands/importmobilepaypayments.py
+++ b/stregsystem/management/commands/importmobilepaypayments.py
@@ -258,11 +258,13 @@ class Command(BaseCommand):
         amount = transaction['amount']
 
         comment = strip_emoji(transaction['message'])
+        name = transaction['name']  # Danish legal name, no reason to sanitize.
 
         MobilePayment.objects.create(
             amount=amount,  # already in streg-ører
             member=mobile_payment_exact_match_member(comment),
             comment=comment,
+            name=name,
             timestamp=payment_datetime,
             transaction_id=trans_id,
             status=MobilePayment.UNSET,

--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -433,9 +433,11 @@ def batch_payment(request):
 @permission_required("stregsystem.mobilepaytool_access")
 def mobilepaytool(request):
     paytool_form_set = modelformset_factory(
-        MobilePayment, form=MobilePayToolForm, extra=0, fields=('timestamp', 'amount', 'member', 'comment', 'status')
-    )  # TODO: 'customer_name' removed, MobilepayAPI does not
-    # TODO-cont: have that information at this point in time - add back 'customer_name' if available in future
+        MobilePayment,
+        form=MobilePayToolForm,
+        extra=0,
+        fields=('timestamp', 'amount', 'member', 'customer_name', 'comment', 'status'),
+    )
     data = dict()
     if request.method == "GET":
         data['formset'] = paytool_form_set(queryset=make_unprocessed_mobilepayment_query())


### PR DESCRIPTION
The new Vipps API gives us the full legal name of payers, this is now
added to the interface.

Closes #441 