### PR TITLE
Fix wrong parameter supplied MobilePayment-object

### DIFF
--- a/stregsystem/management/commands/importmobilepaypayments.py
+++ b/stregsystem/management/commands/importmobilepaypayments.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
             amount=amount,  # already in streg-ører
             member=mobile_payment_exact_match_member(comment),
             comment=comment,
-            name=name,
+            customer_name=name,
             timestamp=payment_datetime,
             transaction_id=trans_id,
             status=MobilePayment.UNSET,


### PR DESCRIPTION
MobilePay imports didn't work because I used the wrong field name.
