### PR TITLE
Rollback Django to 4.1 for MySQL 5.7 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.13
+Django==4.1.13
 Pillow==10.3.0
 Coverage==7.5.1
 pytz==2024.1


### PR DESCRIPTION
MySQL 5.7 support was removed in 4.2
