### PR TITLE
Remove old autofocus hack

### DIFF
--- a/stregsystem/templates/stregsystem/base.html
+++ b/stregsystem/templates/stregsystem/base.html
@@ -19,7 +19,7 @@
     var media_url = "{% get_media_prefix %}";
 </script>
 </head>
-<body onLoad='if (document.focusform) {document.focusform.quickbuy.focus()}'>
+<body>
 {% comment %}
 <pre>{% filter escape %}{% debug %}{% endfilter %}</pre>
 


### PR DESCRIPTION
The quickbuy input box will automatically be focused because it uses the HTML `autofocus` attribute:

https://github.com/f-klubben/stregsystemet/blob/4165e933766cb0ed615176befce88b747f0b0077/stregsystem/templates/stregsystem/index.html#L34-L36

It seems like autofocus is also implemented in JS, probably because Internet Explorer didn't support the HTML attribute. The JS hack is pretty bad for multiple reasons. One is that it can run several seconds after the user has started to use the web page, in which case it will just yank the focus away from whatever the user was doing.

I think we should get rid of it :)