### PR TITLE
Upgrade header to modern HTML

### DIFF
--- a/stregsystem/static/stregsystem/stregsystem.css
+++ b/stregsystem/static/stregsystem/stregsystem.css
@@ -3,6 +3,22 @@ body {
        background-color: white;
 }
 
+header {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  padding: 3px 4vw;
+  column-gap: 4vw;
+  text-align: center;
+  place-items: center;
+
+  & .left {
+    justify-self: start;
+  }
+  & .right {
+    justify-self: end;
+  }
+}
+
 h1 { color: red }
 
 /*div { border-color: red;

--- a/stregsystem/templates/stregsystem/base.html
+++ b/stregsystem/templates/stregsystem/base.html
@@ -28,29 +28,20 @@
 <div id="canvas-container"></div>
 <img id="rocket" src="{% static "/stregsystem/rocket.png" %}">
 <script src="{% static "/stregsystem/fireworks.js" %}"></script>
-
-<table width="100%">
-    <tr>
-        <td>
-          <center>
-            <input type="button" onclick="location.href='/{{room.id}}';" value="Genstart" tabindex="10" accesskey="q">
-          </center>
-        </td>
-        <td align=center>
-            <h1>{% block heading %}TREOENs STREGSYSTEM
-{% if room.id != 1 %}
- : {{room.description}}
-{% endif %}
-{% endblock %}</h1>
-        </td>
-        <td>
-          <center>
-            <input type="button" onclick="location.href='/{{room.id}}';" value="Menu" tabindex="11" />
-            <input type="button" onclick="location.href='/signup'" value="Tilmeld" tabindex="12"/>
-          </center>
-        </td>
-    </tr>
-</table>
+<header>
+  <div class="left">
+    <input type="button" onclick="location.href='/{{room.id}}';" value="Genstart" tabindex="10" accesskey="q">
+  </div>
+  <h1>
+    {% block heading %}
+      TREOENs STREGSYSTEM {% if room.id != 1 %} : {{room.description}} {% endif %}
+    {% endblock %}
+  </h1>
+  <div class="right">
+    <input type="button" onclick="location.href='/{{room.id}}';" value="Menu" tabindex="11" />
+    <input type="button" onclick="location.href='/signup'" value="Tilmeld" tabindex="12"/>
+  </div>
+</header>
 <hr>
 
 {% block content %}{% endblock %}


### PR DESCRIPTION
It turns out the heading text has never been centered. Here you can see:
 - 1. the original header
 - 2. the new header with a sign up button
 - 3. this new design which ensures that the heading text is actually centered

![Skærmbillede fra 2024-08-28 00-42-34](https://github.com/user-attachments/assets/328baad3-9c2f-4574-bfec-92666b8cf4b1)

And on a narrow screen:

![Skærmbillede fra 2024-08-28 00-43-42](https://github.com/user-attachments/assets/2f9b395f-f3f6-4325-a82a-b008e9861d8f)

This new design also ensures that there is consistent spacing between the buttons and the edge of the screen.

Fixes #478.
Is a partial implementation of #473 and #474.