### PR TITLE
Hotfix: 'Ignore' status not being updated

### DIFF
--- a/stregsystem/models.py
+++ b/stregsystem/models.py
@@ -529,6 +529,7 @@ class MobilePayment(ApprovalModel):
             processed_mobile_payment.status = row['status']
             processed_mobile_payment.member = Member.objects.get(id=row['member'].id)
             processed_mobile_payment.submit_processed_mobile_payment(admin_user)
+            processed_mobile_payment.save()
 
         # Return how many records were modified.
         return len(mobile_payment_ids)


### PR DESCRIPTION
When selecting 'ignore' as an option, the status didn't update correctly.

Tests should be added for this.