### PR TITLE
Hotfix: Update trusted origins in CSRF-settings

### DIFF
--- a/treo/settings.py
+++ b/treo/settings.py
@@ -72,7 +72,7 @@ DEBUG = cfg.getboolean("debug", "DEBUG")
 
 CSRF_COOKIE_SECURE = cfg.getboolean("debug", "CSRF_COOKIE_SECURE")
 CSRF_COOKIE_HTTPONLY = cfg.getboolean("debug", "CSRF_COOKIE_HTTPONLY")
-CSRF_TRUSTED_ORIGINS = ["https://fappen.fklub.dk"]
+CSRF_TRUSTED_ORIGINS = ["https://fappen.fklub.dk", "https://stregsystem.fklub.dk"]
 SESSION_COOKIE_SECURE = cfg.getboolean("debug", "SESSION_COOKIT_SECURE")
 
 SECURE_BROWSER_XSS_FILTER = cfg.getboolean("debug", "SECURE_BROWSER_XSS_FILTER")


### PR DESCRIPTION
Doing deployment of new production stack, using routing requests from apache to gunicorn, required a new origin to be allowed

This change is already locally applied on server