### PR TITLE
Make education and E-mail mandatory in Signup form

### DIFF
--- a/stregsystem/forms.py
+++ b/stregsystem/forms.py
@@ -84,12 +84,11 @@ class SignupForm(forms.ModelForm):
         model = Member
         fields = ('notes', 'username', 'email', 'firstname', 'lastname', 'gender')
         widgets = {
-            'notes': forms.TextInput(attrs={'autocomplete': "off",
-                                            'placeholder': "sw, dat, bait, ixd, dad, etc.",
-                                            'required': "required"}),
+            'notes': forms.TextInput(
+                attrs={'autocomplete': "off", 'placeholder': "sw, dat, bait, ixd, dad, etc.", 'required': "required"}
+            ),
             'username': forms.TextInput(attrs={'autocomplete': "off"}),
-            'email': forms.TextInput(attrs={'autocomplete': "off",
-                                            'required': "required"}),
+            'email': forms.TextInput(attrs={'autocomplete': "off", 'required': "required"}),
             'firstname': forms.TextInput(attrs={'autocomplete': "off"}),
             'lastname': forms.TextInput(attrs={'autocomplete': "off"}),
             'gender': forms.Select(),

--- a/stregsystem/forms.py
+++ b/stregsystem/forms.py
@@ -84,7 +84,9 @@ class SignupForm(forms.ModelForm):
         model = Member
         fields = ('notes', 'username', 'email', 'firstname', 'lastname', 'gender')
         widgets = {
-            'notes': forms.TextInput(attrs={'autocomplete': "off", 'placeholder': "sw, dat, bait, ixd, dad, etc."}),
+            'notes': forms.TextInput(attrs={'autocomplete': "off",
+                                            'placeholder': "sw, dat, bait, ixd, dad, etc.",
+                                            'required': "required"}),
             'username': forms.TextInput(attrs={'autocomplete': "off"}),
             'email': forms.TextInput(attrs={'autocomplete': "off"}),
             'firstname': forms.TextInput(attrs={'autocomplete': "off"}),
@@ -100,6 +102,9 @@ class SignupForm(forms.ModelForm):
             'gender': 'Biologisk køn(*)',
         }
         error_messages = {
+            'notes': {
+                'required': 'Udfyldning af `Studieretning` er påkrævet.',
+            },
             'username': {
                 'required': 'Udfyldning af `Brugernavn` er påkrævet.',
                 'max_length': 'Længden af `Brugernavn` må ikke overstige 16 tegn.',

--- a/stregsystem/forms.py
+++ b/stregsystem/forms.py
@@ -88,7 +88,8 @@ class SignupForm(forms.ModelForm):
                                             'placeholder': "sw, dat, bait, ixd, dad, etc.",
                                             'required': "required"}),
             'username': forms.TextInput(attrs={'autocomplete': "off"}),
-            'email': forms.TextInput(attrs={'autocomplete': "off"}),
+            'email': forms.TextInput(attrs={'autocomplete': "off",
+                                            'required': "required"}),
             'firstname': forms.TextInput(attrs={'autocomplete': "off"}),
             'lastname': forms.TextInput(attrs={'autocomplete': "off"}),
             'gender': forms.Select(),
@@ -108,6 +109,9 @@ class SignupForm(forms.ModelForm):
             'username': {
                 'required': 'Udfyldning af `Brugernavn` er påkrævet.',
                 'max_length': 'Længden af `Brugernavn` må ikke overstige 16 tegn.',
+            },
+            'email': {
+                'required': 'Udfyldning af `E-Mail` er påkrævet.',
             },
             'firstname': {
                 'required': 'Udfyldning af `Fornavn` er påkrævet.',


### PR DESCRIPTION
Resolves #489 

Apparently, only some of the input types in Django forms are 'required' by default, this PR forces the other input types' required-attribute.