### PR TITLE
Improve QR Code Rendering

### DIFF
--- a/stregsystem/static/stregsystem/stregsystem.css
+++ b/stregsystem/static/stregsystem/stregsystem.css
@@ -147,6 +147,7 @@ table h2, table h3 {
 .qr-code {
     position: relative;
     z-index: 2147483647;
+    image-rendering: pixelated;
 }
 
 @keyframes blink-frame {


### PR DESCRIPTION
Instead of using the default scaling algorithm (bilinear?) use the pixelated image rendering algorithm so it is always nice and crisp :^)