### PR TITLE
Make header sticky

### DIFF
--- a/stregsystem/static/stregsystem/stregsystem.css
+++ b/stregsystem/static/stregsystem/stregsystem.css
@@ -4,6 +4,9 @@ body {
 }
 
 header {
+  position: sticky;
+  top: 0;
+  background-color: Canvas;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   padding: 3px 4vw;


### PR DESCRIPTION
Make the header stick to the top of the viewport so if you scroll down a web page, you can still use the header controls.

This works best when combined with #525 

![image](https://github.com/user-attachments/assets/b7cfa426-25e9-4a78-9dd6-109143c85ffd)

