### PR TITLE
Improve menu form

### DIFF
--- a/stregsystem/templates/stregsystem/menu.html
+++ b/stregsystem/templates/stregsystem/menu.html
@@ -12,8 +12,21 @@
     padding-top: .8em;
     padding-bottom: 1em;
   }
-  #productlist {
+  #product-buy-form {
     padding-bottom: 1em;
+
+    & button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font: inherit;
+      text-decoration: underline;
+      color: LinkText;
+
+      &:active{
+        color: ActiveText;
+      }
+    }
   }
 </style>
 {% endblock %}
@@ -76,58 +89,51 @@
   {% endblock %}
   </div>
 
-  <div id="productlist" class="horizontal-table">
-    {% block products %}
-      {% autoescape off %}
-      {% if product_list %}
-        <table class="default">
-          <tr>
-            <th>Produkt</th>
-            <th>Pris</th>
-          </tr>
-          {% for product in product_list|partition:"2"|first %}
-            <tr>
-              <td>
-                <form method="post" action="/{{ room.id }}/sale/{{ member.id }}/">
-                  {% csrf_token %}
-                  <a href="" onclick="this.closest('form').submit();return false;">{{product.name}}</a>
-                  <input type="hidden" value="{{ product.id }}" name="product_id">
-                  <input type="hidden" value="{{ room.id }}" name="room_id">
-                  <input type="hidden" value="{{ member.id }}" name="member_id">
-                </form>
-              </td>
-              <td class="price">{{product.price|money}} kr</td>
-            </tr>
-          {% endfor %}
-        </table>
-        {% if product_list|partition:"2"|last %}
+  {% block products %}
+    {% autoescape off %}
+    {% if product_list %}
+      <form method="post" action="/{{ room.id }}/sale/{{ member.id }}/" id="product-buy-form" name="product-buy-form">
+        {% csrf_token %}
+        <input type="hidden" value="{{ room.id }}" name="room_id">
+        <input type="hidden" value="{{ member.id }}" name="member_id">
+        <div class="horizontal-table">
           <table class="default">
             <tr>
               <th>Produkt</th>
               <th>Pris</th>
             </tr>
-            {% for product in product_list|partition:"2"|last %}
-            <tr>
-              <td>
-                <form method="post" action="/{{ room.id }}/sale/{{ member.id }}/">
-                  {% csrf_token %}
-                  <a href="" onclick="this.closest('form').submit();return false;">{{product.name}}</a>
-                  <input type="hidden" value="{{ product.id }}" name="product_id">
-                  <input type="hidden" value="{{ room.id }}" name="room_id">
-                  <input type="hidden" value="{{ member.id }}" name="member_id">
-                </form>
-              </td>
-              <td class="price">{{product.price|money}} kr</td>
-            </tr>
+            {% for product in product_list|partition:"2"|first %}
+              <tr>
+                <td>
+                  <button value="{{ product.id }}" name="product_id">{{product.name}}</button>
+                </td>
+                <td class="price">{{product.price|money}} kr</td>
+              </tr>
             {% endfor %}
           </table>
-        {% endif %}
-      {% else %}
-        <p>Ingen produkter.</p>
+          {% if product_list|partition:"2"|last %}
+            <table class="default">
+              <tr>
+                <th>Produkt</th>
+                <th>Pris</th>
+              </tr>
+              {% for product in product_list|partition:"2"|last %}
+              <tr>
+                <td>
+                  <button value="{{ product.id }}" name="product_id">{{product.name}}</button>
+                </td>
+                <td class="price">{{product.price|money}} kr</td>
+              </tr>
+              {% endfor %}
+            </table>
+          </div>
+        </form>
       {% endif %}
-      {% endautoescape %}
-    {% endblock %}
-  </div>
+    {% else %}
+      <p>Ingen produkter.</p>
+    {% endif %}
+    {% endautoescape %}
+  {% endblock %}
   <br />
   {% include "stregsystem/purchase_heatmap.html" %}
 </main>

--- a/stregsystem/templates/stregsystem/purchase_heatmap.html
+++ b/stregsystem/templates/stregsystem/purchase_heatmap.html
@@ -152,7 +152,7 @@
     }
 
     function updateAllProductNumbers(hide=false){
-        document.querySelectorAll("input[name='product_id']")
+        document.querySelectorAll("button[name='product_id']")
             .forEach(p => changeProductCountElement(p.parentElement, 0, hide))
     }
 
@@ -184,7 +184,7 @@
         }
 
         for (const [product_id, count] of Object.entries(product_counts)){
-            const productCountElement = document.querySelector(`input[name='product_id'][value='${product_id}']`)?.parentElement;
+            const productCountElement = document.querySelector(`button[name='product_id'][value='${product_id}']`)?.parentElement;
 
             if (productCountElement === undefined){
                 console.warn(`Product doesn't exist in tabel: ${product_id}`);


### PR DESCRIPTION
 Improvements to the product buying form in the user menu:
 - No longer uses JS.
 - Page size is much smaller.
 - Form is much more accessible.

There are no visual changes, except for some edge cases.

Instead of creating a new form for each product, we create a single form with a custom submit button for each product. Because we don't have to create 1000 forms, we save a lot of bandwidth. This also contributes to accessibility, since the browser can assert that this is a single form with different options, rather than a thousand separate forms that might not be related to each other.

Instead of using a link that invokes JS to submit a form, we use a button that natively submits the form. This is a big accessibility improvement, as it is now clear that the button is related to the form, and it is clear that the product name in the button is highly relevant.