### PR TITLE
Maintenance: Update nix dependencies and modernize nix code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732749044,
-        "narHash": "sha256-T38FQOg0BV5M8FN1712fovzNakSOENEYs+CSkg31C9Y=",
+        "lastModified": 1775595990,
+        "narHash": "sha256-OEf7YqhF9IjJFYZJyuhAypgU+VsRB5lD4DuiMws5Ltc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c5b4ecbed5b155b705336aa96d878e55acd8685",
+        "rev": "4e92bbcdb030f3b4782be4751dc08e6b6cb6ccf2",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.11",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
     # define nixpkgs version to use
     inputs = {
-        nixpkgs.url = "nixpkgs/nixos-24.11";
+        nixpkgs.url = "nixpkgs/nixos-25.11";
     };
 
     outputs = { self, nixpkgs }: let 
@@ -11,11 +11,11 @@
         pkgs = import nixpkgs { inherit system; };
     in {
         # Define the shell, here we're just setting the packages required for the devshell
-        devShells.${system}.default = import ./nix-support/shell.nix { inherit pkgs; };
+        devShells.${system}.default = self.packages.${system}.default.shell;
 
         # Default package for the stregsystem
         packages.${system} = {
-            default = import ./nix-support { inherit pkgs; };
+            default = pkgs.callPackage ./nix-support { };
 
             # Test VM
             vm = (nixpkgs.lib.nixosSystem {
@@ -25,7 +25,7 @@
                     {
                         users.users.root.password = "root";
                         networking.hostName = "fklub";
-                        system.stateVersion = "24.05";
+                        system.stateVersion = "25.11";
                         stregsystemet = {
                             enable = true;
                             port = 80;

--- a/manage.py
+++ b/manage.py
@@ -4,8 +4,7 @@ import sys
 
 import setup_utils
 
-
-if __name__ == "__main__":
+def main():
     cleanArgs = setup_utils.check_for_debugger(sys.argv)
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "treo.settings")
@@ -25,3 +24,6 @@ if __name__ == "__main__":
             )
         raise
     execute_from_command_line(cleanArgs)
+
+if __name__ == "__main__":
+    main()

--- a/nix-support/default.nix
+++ b/nix-support/default.nix
@@ -1,21 +1,31 @@
-{pkgs ? import <nixpkgs> {}, ...}: let
-    env = pkgs.python311.withPackages (import ./dependencies.nix { inherit pkgs; });
-in pkgs.stdenv.mkDerivation {
-    pname = "stregsystemet";
-    version = "latest";
+{ python3Packages, writeText, callPackage, mkShell, mailhog, black }:
+
+let
+    projectFile = builtins.fromTOML (builtins.readFile ../pyproject.toml);
+    pname = projectFile.project.name;
+    version = projectFile.project.version;
     src = ../.;
-
-    installPhase = ''
-        mkdir -p $out/bin
-        mkdir -p $out/share/stregsystemet
-
-        cp local.cfg.skel local.cfg
-        echo "${env.interpreter} $out/share/stregsystemet/manage.py \$@" > $out/bin/stregsystemet
-        sed -i '1 i #!${pkgs.bash}/bin/bash' $out/bin/stregsystemet
-        chmod +x $out/bin/stregsystemet
-
-        sed -i '1d' manage.py
-
-        cp ./* $out/share/stregsystemet -r
+    dependencies = callPackage ./dependencies.nix { };
+    pyprojectAddition = writeText "pyproject-addition.toml" ''
+        [project.scripts]
+        ${pname} = "treo.manage:main"
     '';
+in
+
+python3Packages.buildPythonApplication {
+    inherit pname version src;
+    propagatedBuildInputs = dependencies;
+    pyproject = true;
+    build-system = [ python3Packages.setuptools ];
+    # prepare
+    preBuild = ''
+        sed -i 's/^import setup_utils$/from . import setup_utils/' manage.py
+        cp manage.py treo
+        cp setup_utils.py treo
+        cat ${pyprojectAddition} >> pyproject.toml
+    '';
+
+    passthru.shell = mkShell {
+        packages = dependencies ++ [mailhog black];
+    };
 }

--- a/nix-support/dependencies.nix
+++ b/nix-support/dependencies.nix
@@ -1,8 +1,12 @@
-{pkgs}: let
+{ callPackage, lib, python3Packages }: let
     # Based on requirements.txt, determine dependencies to fetch from nixpkgs
     requirements = ../requirements.txt;
     # Read file and split it into lines
-    lines = pkgs.lib.lists.remove "" (pkgs.lib.strings.splitString "\n" (builtins.readFile requirements));
-    packages = map (pkg: builtins.elemAt (pkgs.lib.strings.splitString "==" pkg) 0) lines;
+    lines = lib.lists.remove "" (lib.strings.splitString "\n" (builtins.readFile requirements));
+    packages = map (pkg: builtins.elemAt (lib.strings.splitString "==" pkg) 0) lines;
     filteredPackages = builtins.filter (pkg: pkg != "Django-Select2") packages;
-in py: [(pkgs.callPackage ./django-select2.nix { inherit pkgs py; })] ++ map (pkg: py.${pkgs.lib.toLower pkg}) filteredPackages
+    
+    django-select2 = callPackage ./django-select2.nix { };
+in
+
+[django-select2] ++ map (pkg: python3Packages.${lib.toLower pkg}) filteredPackages

--- a/nix-support/django-select2.nix
+++ b/nix-support/django-select2.nix
@@ -1,20 +1,24 @@
-{pkgs, py}:
+{ python3Packages, fetchurl }:
 
-py.buildPythonPackage {
-    pname = "Django-Select2";
+let
+    pname = "django_select2";
     version = "8.1.2";
-    src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/7f/af/2fc371e1dea6686b588ab9cd445e55b63248a525f8c90550767a42dd77bb/django_select2-8.1.2.tar.gz";
-        sha256 = "sha256-9EaF7hw5CQqt4B4+vCVnAvBWIPPHijwmhECtmmYHCHY=";
-    };
+    name = "${pname}-${version}";
+    url = "https://files.pythonhosted.org/packages/7f/af/2fc371e1dea6686b588ab9cd445e55b63248a525f8c90550767a42dd77bb/${name}.tar.gz";
+    sha256 = "sha256-9EaF7hw5CQqt4B4+vCVnAvBWIPPHijwmhECtmmYHCHY=";
+    src = fetchurl { inherit url sha256; };
+in
+
+python3Packages.buildPythonPackage {
+    inherit pname version src;
     format = "pyproject";
     doCheck = false;
     buildInputs = [];
     checkInputs = [];
     nativeBuildInputs = [];
-    propagatedBuildInputs = [
-        py.django-appconf
-        py.flit-scm
+    propagatedBuildInputs = with python3Packages; [
+        django-appconf
+        flit-scm
     ];
 }
 

--- a/nix-support/shell.nix
+++ b/nix-support/shell.nix
@@ -1,5 +1,0 @@
-{pkgs ? import <nixpkgs> {}, ...}:
-
-pkgs.mkShell {
-    packages = ((import ./dependencies.nix { inherit pkgs; }) pkgs.python311Packages) ++ [pkgs.mailhog pkgs.black];
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ authors = [
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 readme = "README.md"
+
+[tool.setuptools.packages.find]
+include = ["stregsystem", "treo", "media", "kiosk", "razzia", "openapi", "stregreport"]


### PR DESCRIPTION
Hi, i was looking through your backlog of pull requests and the recent changes. I noticed that nobody touched the nix setup since i last used it to test the system. That's fine, but i would like to still have a look at the system sometimes so i'd like to also update the nix code occasionally.

I wanted to set the nix channel to unstable, but unfortunately django is broken on unstable, so you get stable nix.

Other than the nix updates, i have also adjusted a few files such that the system is still the exact same, but pyproject is able to generate an executable for the stregsystem.

For reviewer:
* my experience with django outside of stregsystemet is none, so if anyone more experienced can answer whether there is a better way to run manage.py from pyproject i would love to adjust it
* How is the system run in production? Preferably i want the nix build to output a production ready package to have something nice and testable
* Since unstable is not working, i fear that new versions of django will break the system. This is just for info, but i think you should be aware that this dependency might break in the future.