### PR TITLE
Bugfix: get_member_id only active accounts

### DIFF
--- a/stregsystem/views.py
+++ b/stregsystem/views.py
@@ -692,7 +692,7 @@ def get_member_id(request):
         return HttpResponseBadRequest("Parameter missing: username")
 
     try:
-        member = Member.objects.get(username=username)
+        member = Member.objects.get(username=username, active=True)
     except Member.DoesNotExist:
         return HttpResponseBadRequest("Member not found")
 


### PR DESCRIPTION
Fixed issue of inactive accounts still getting found with `get_member_id` function.
This caused cases with users with duplicate usernames and the api throwing an error.
