### PR TITLE
Bugfix: Razzia now queries for a single user, not a list

### DIFF
--- a/razzia/views.py
+++ b/razzia/views.py
@@ -31,7 +31,6 @@ def razzia_view_single(request, razzia_id, queryname, title=None):
         member = Member.objects.get(username__iexact=queryname, active=True)
     except Member.DoesNotExist:
         return render(request, template, locals())
-    
 
     entries = list(razzia.razziaentry_set.filter(member__pk=member.pk).order_by('-time'))
     turns_already = len(entries)

--- a/razzia/views.py
+++ b/razzia/views.py
@@ -27,7 +27,7 @@ def razzia_view_single(request, razzia_id, queryname, title=None):
     if queryname is None:
         return render(request, template, locals())
 
-    result = list(Member.objects.filter(username__iexact=queryname))
+    result = list(Member.objects.filter(username__iexact=queryname, active=True))
     if len(result) == 0:
         return render(request, template, locals())
 

--- a/razzia/views.py
+++ b/razzia/views.py
@@ -28,7 +28,7 @@ def razzia_view_single(request, razzia_id, queryname, title=None):
         return render(request, template, locals())
 
     try:
-        member = Member.objects.get(username__iexact=username, active=True)
+        member = Member.objects.get(username__iexact=queryname, active=True)
     except Member.DoesNotExist:
         return render(request, template, locals())
     

--- a/razzia/views.py
+++ b/razzia/views.py
@@ -27,11 +27,11 @@ def razzia_view_single(request, razzia_id, queryname, title=None):
     if queryname is None:
         return render(request, template, locals())
 
-    result = list(Member.objects.filter(username__iexact=queryname, active=True))
-    if len(result) == 0:
+    try:
+        member = Member.objects.get(username__iexact=username, active=True)
+    except Member.DoesNotExist:
         return render(request, template, locals())
-
-    member = result[0]
+    
 
     entries = list(razzia.razziaentry_set.filter(member__pk=member.pk).order_by('-time'))
     turns_already = len(entries)

--- a/stregreport/views.py
+++ b/stregreport/views.py
@@ -85,7 +85,6 @@ def razzia_view_single(request, razzia_id, queryname, razzia_type=BreadRazzia.BR
     except Member.DoesNotExist:
         return render(request, template, locals())
 
-
     if razzia_type == BreadRazzia.FNUGFALD:
         username = queryname
         member_name = member.firstname + " " + member.lastname

--- a/stregreport/views.py
+++ b/stregreport/views.py
@@ -80,11 +80,11 @@ def razzia_view_single(request, razzia_id, queryname, razzia_type=BreadRazzia.BR
     if queryname is None:
         return render(request, templates[razzia_type], locals())
 
-    result = list(Member.objects.filter(username__iexact=queryname))
-    if len(result) == 0:
-        return render(request, templates[razzia_type], locals())
+    try:
+        member = Member.objects.get(username__iexact=queryname, active=True)
+    except Member.DoesNotExist:
+        return render(request, template, locals())
 
-    member = result[0]
 
     if razzia_type == BreadRazzia.FNUGFALD:
         username = queryname
@@ -177,7 +177,7 @@ def razzia_view(request):
         return render(request, 'admin/stregsystem/razzia/error_wizarderror.html', {})
 
     try:
-        user = Member.objects.get(username__iexact=username)
+        user = Member.objects.get(username__iexact=username, active=True)
     except (Member.DoesNotExist, Member.MultipleObjectsReturned):
         return render(
             request,


### PR DESCRIPTION
It used to query a list of users with the name, active or inactive. Now it only queries for a single active user, hence better.

This is a important fix for me, since i have a duplicate username with an old inactive account. This will fix my issues 😁