### PR TITLE
Fix MobilePay exact-match deposit emails

### DIFF
--- a/stregsystem/models.py
+++ b/stregsystem/models.py
@@ -386,7 +386,11 @@ class Payment(BaseModel):  # id automatisk...
             self.member.save()
             if self.member.email != "" and self.amount != 0:
                 if '@' in parseaddr(self.member.email)[1] and self.member.want_spam:
-                    send_payment_mail(self.member, self.amount, mbpayment.comment if mbpayment else None)
+                    send_payment_mail(
+                        self.member,
+                        self.amount,
+                        mbpayment.payment_mail_comment() if mbpayment else None,
+                    )
 
     def log_from_mobile_payment(self, processed_mobile_payment, admin_user: User):
         LogEntry.objects.log_action(
@@ -477,6 +481,12 @@ class MobilePayment(ApprovalModel):
             f"{self.member.username if self.member is not None else 'Not assigned'}, {self.customer_name}, "
             f"{self.timestamp}, {self.amount}, {self.transaction_id}, {self.comment}"
         )
+
+    def payment_mail_comment(self):
+        if self.member is not None and self.comment is not None:
+            if self.comment.strip().casefold() == self.member.username.casefold():
+                return None
+        return self.comment
 
     @transaction.atomic()
     def delete(self, *args, **kwargs):

--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -1602,6 +1602,27 @@ class MobilePaymentTests(TestCase):
             Member.objects.get(username__exact="jdoe").balance, self.members["jdoe"]['balance'] + mobile_payment.amount
         )
 
+    @mock.patch('stregsystem.models.send_payment_mail', autospec=True)
+    def test_exact_match_mobilepayment_sends_automatic_mail(self, mock_mail_method: MagicMock):
+        mobile_payment = MobilePayment.objects.get(transaction_id__exact="016E027417049990")
+        mobile_payment.status = MobilePayment.APPROVED
+        mobile_payment.save()
+
+        MobilePayment.submit_all_processed_mobile_payments(self.super_user)
+
+        mock_mail_method.assert_called_once_with(mobile_payment.member, mobile_payment.amount, None)
+
+    @mock.patch('stregsystem.models.send_payment_mail', autospec=True)
+    def test_manually_matched_mobilepayment_sends_comment_mail(self, mock_mail_method: MagicMock):
+        mobile_payment = MobilePayment.objects.get(transaction_id__exact="232E027452733666")
+        mobile_payment.member = Member.objects.get(username__exact="tables")
+        mobile_payment.status = MobilePayment.APPROVED
+        mobile_payment.save()
+
+        MobilePayment.submit_all_processed_mobile_payments(self.super_user)
+
+        mock_mail_method.assert_called_once_with(mobile_payment.member, mobile_payment.amount, mobile_payment.comment)
+
     def test_ignored_payment_balance(self):
         # member balance unchanged
         self.assertEqual(Member.objects.get(username__exact="tester").balance, self.members["tester"]['balance'])


### PR DESCRIPTION
## Summary
- Treat MobilePay comments that exactly match the member username as automatic payments for deposit email selection.
- Keep passing the original comment for manually matched MobilePay payments so the manual/shame email still works when the comment was wrong.
- Add regression coverage for both exact-match and manually matched MobilePay payments.

Fixes #551

## Tests
- .venv/bin/python manage.py test stregsystem.tests.MobilePaymentTests.test_exact_match_mobilepayment_sends_automatic_mail stregsystem.tests.MobilePaymentTests.test_manually_matched_mobilepayment_sends_comment_mail stregsystem.tests.AutoPaymentTests
- .venv/bin/python manage.py test stregsystem.tests.MobilePaymentTests