### PR TITLE
Use MobilePay payment links for QR clicks

### DIFF
--- a/stregsystem/templates/stregsystem/menu_userpay.html
+++ b/stregsystem/templates/stregsystem/menu_userpay.html
@@ -36,7 +36,7 @@
       <div>
         <b>{{amount | floatformat:2}} kr.</b>
         <br /><br />
-        <a href="mobilepay://send?phone=90601&comment={{ member.username }}&amount={{ amount }}">
+        <a href="{% mobilepay_link member.username amount %}">
           {% mobilepay_qr member.username amount %}
         </a>
       </div>
@@ -45,7 +45,7 @@
     <div>
       <b>Valgfrit beløb</b>
       <br /><br />
-      <a href="mobilepay://send?phone=90601&comment={{ member.username }}">
+      <a href="{% mobilepay_link member.username %}">
         {% mobilepay_qr member.username %}
       </a>
       <br />
@@ -55,4 +55,3 @@
 </main>
 
 {% endblock %}
-

--- a/stregsystem/templatetags/mobilepay_qr.py
+++ b/stregsystem/templatetags/mobilepay_qr.py
@@ -1,7 +1,13 @@
 from django import template
 from django.template.loader import get_template
+from stregsystem.utils import mobilepay_launch_uri
 
 register = template.Library()
+
+
+@register.simple_tag
+def mobilepay_link(username, amount=None):
+    return mobilepay_launch_uri(username, amount)
 
 
 @register.inclusion_tag('stregsystem/mobilepay_qr.html')

--- a/stregsystem/tests.py
+++ b/stregsystem/tests.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import User
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages import get_messages
 from django.forms import model_to_dict
+from django.template import Context, Template
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -50,6 +51,7 @@ from stregsystem.templatetags.stregsystem_extras import caffeine_emoji_render
 from stregsystem.utils import (
     make_active_productlist_query,
     mobile_payment_exact_match_member,
+    mobilepay_launch_uri,
     strip_emoji,
     PaymentToolException,
 )
@@ -64,6 +66,26 @@ def assertCountEqual(case, *args, **kwargs):
 
 
 class ModelMiscTests(TestCase):
+    def test_mobilepay_link_template_tag(self):
+        template = Template("{% load mobilepay_qr %}{% mobilepay_link 'jdoe' 100 %}")
+
+        self.assertEqual(
+            template.render(Context({})),
+            "https://mobilepay.dk/erhverv/betalingslink/betalingslink-svar?phone=90601&amp;comment=jdoe&amp;amount=100",
+        )
+
+    def test_mobilepay_launch_uri_uses_payment_link(self):
+        self.assertEqual(
+            mobilepay_launch_uri("jdoe", 50),
+            "https://mobilepay.dk/erhverv/betalingslink/betalingslink-svar?phone=90601&comment=jdoe&amount=50",
+        )
+
+    def test_mobilepay_launch_uri_without_amount(self):
+        self.assertEqual(
+            mobilepay_launch_uri("jdoe", None),
+            "https://mobilepay.dk/erhverv/betalingslink/betalingslink-svar?phone=90601&comment=jdoe",
+        )
+
     def test_price_display_none(self):
         v = price_display(None)
         self.assertEqual(v, "0.00 kr.")

--- a/stregsystem/utils.py
+++ b/stregsystem/utils.py
@@ -181,7 +181,9 @@ def mobilepay_launch_uri(comment: str, amount: float) -> str:
     if amount is not None:
         query['amount'] = amount
 
-    return 'mobilepay://send?{}'.format(urllib.parse.urlencode(query))
+    return 'https://mobilepay.dk/erhverv/betalingslink/betalingslink-svar?{}'.format(
+        urllib.parse.urlencode(query)
+    )
 
 
 class stregsystemTestRunner(DiscoverRunner):


### PR DESCRIPTION
## Summary
- Switch the clickable MobilePay QR links from the custom mobilepay://send scheme to MobilePay HTTPS payment link URLs.
- Add a mobilepay_link template tag so the QR hrefs and generated QR code use the same URL helper.
- Cover the URL helper and template tag with regression tests.

Fixes #574

## Tests
- .venv/bin/python manage.py test stregsystem.tests.ModelMiscTests.test_mobilepay_link_template_tag stregsystem.tests.ModelMiscTests.test_mobilepay_launch_uri_uses_payment_link stregsystem.tests.ModelMiscTests.test_mobilepay_launch_uri_without_amount
- .venv/bin/python manage.py test stregsystem.tests.ModelMiscTests
- git diff --check